### PR TITLE
extremely hacky code to add pythoncore support for run configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## [Unreleased]
 
+- Add support for PyCharm Community & Professional
+
 ## [1.2.1] - 2024-07-24
 
 - Remove screenshots from plugin.xml. (JetBrains Marketplace guidelines)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ from mise config files. see: **[mise-en-place](https://mise.jdx.dev)**
 - **IntelliJ IDEA**
 - **GoLand**
 - **WebStorm**
+- **PyCharm Community** & **PyCharm Professional** (Note, due to different Python plugins between Community/Professional, there are two different plugins for PyCharm)
 - _Submit issue if you need other IDE_
 
 ### Features

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
     implementation(project(":mise-products-gradle"))
     implementation(project(":mise-products-goland"))
     implementation(project(":mise-products-nodejs"))
+    implementation(project(":mise-products-pythoncore"))
 }
 
 // Set the JVM language level used to build the project.

--- a/modules/products/pythoncore/README.md
+++ b/modules/products/pythoncore/README.md
@@ -1,0 +1,6 @@
+# PythonCore
+
+Python Community Edition & Professional have different plugins.
+
+`Pythonid` is for PyCharm Professional
+`PythonCore` is for PyCharm Community (this product!), [plugin link](https://plugins.jetbrains.com/plugin/7322-python-community-edition)

--- a/modules/products/pythoncore/build.gradle.kts
+++ b/modules/products/pythoncore/build.gradle.kts
@@ -1,0 +1,19 @@
+fun properties(key: String) = project.findProperty(key).toString()
+
+plugins {
+    id("org.jetbrains.intellij")
+    alias(libs.plugins.kotlin) // Kotlin support
+}
+
+// Configure Gradle IntelliJ Plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
+intellij {
+    version.set("2024.1.4")
+    type.set("PC")
+
+    // Plugin Dependencies
+    plugins.set(listOf("PythonCore:241.18034.55"))
+}
+
+dependencies {
+    implementation(project(":mise-core"))
+}

--- a/modules/products/pythoncore/src/main/kotlin/com/github/l34130/mise/runconfigs/PythonCoreRunConfigurationExtension.kt
+++ b/modules/products/pythoncore/src/main/kotlin/com/github/l34130/mise/runconfigs/PythonCoreRunConfigurationExtension.kt
@@ -1,0 +1,54 @@
+package com.github.l34130.mise.runconfigs
+
+import com.github.l34130.mise.commands.MiseCmd
+import com.github.l34130.mise.settings.ui.RunConfigurationSettingsEditor
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.configurations.RunnerSettings
+import com.intellij.openapi.options.SettingsEditor
+import com.jetbrains.python.run.AbstractPythonRunConfiguration
+import com.jetbrains.python.run.PythonRunConfigurationExtension
+import org.jdom.Element
+
+class PythonCoreRunConfigurationExtension : PythonRunConfigurationExtension() {
+    override fun getEditorTitle(): String = RunConfigurationSettingsEditor.EDITOR_TITLE
+
+    override fun <P : AbstractPythonRunConfiguration<*>> createEditor(configuration: P): SettingsEditor<P> =
+        RunConfigurationSettingsEditor(configuration)
+
+    override fun getSerializationId(): String = RunConfigurationSettingsEditor.SERIALIZATION_ID
+
+    override fun readExternal(
+        runConfiguration: AbstractPythonRunConfiguration<*>,
+        element: Element
+    ) {
+        RunConfigurationSettingsEditor.readExternal(runConfiguration, element)
+    }
+
+    override fun writeExternal(
+        runConfiguration: AbstractPythonRunConfiguration<*>,
+        element: Element
+    ) {
+        RunConfigurationSettingsEditor.writeExternal(runConfiguration, element)
+    }
+
+    override fun patchCommandLine(
+        configuration: AbstractPythonRunConfiguration<*>,
+        runnerSettings: RunnerSettings?,
+        cmdLine: GeneralCommandLine,
+        runnerId: String
+    ) {
+        if (RunConfigurationSettingsEditor.isMiseEnabled(configuration)) {
+            val workingDir = configuration.workingDirectory ?: return
+            MiseCmd.loadEnv(workingDir).forEach { (key, value) ->
+                cmdLine.environment[key] = value
+            }
+        }
+    }
+
+    override fun isApplicableFor(configuration: AbstractPythonRunConfiguration<*>): Boolean = true
+
+    override fun isEnabledFor(
+        applicableConfiguration: AbstractPythonRunConfiguration<*>,
+        runnerSettings: RunnerSettings?
+    ): Boolean = true
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,6 +4,7 @@ include(
     "modules/products/gradle",
     "modules/products/goland",
     "modules/products/nodejs",
+    "modules/products/pythoncore",
 )
 
 rootProject.name = "mise"

--- a/src/main/resources/META-INF/mise-pythoncore.xml
+++ b/src/main/resources/META-INF/mise-pythoncore.xml
@@ -1,0 +1,7 @@
+<idea-plugin>
+    <extensions defaultExtensionNs="PythonCore">
+        <runConfigurationExtension
+                implementation="com.github.l34130.mise.runconfigs.PythonCoreRunConfigurationExtension"
+                id="misePythonCore"/>
+    </extensions>
+</idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -23,4 +23,5 @@
     <depends optional="true" config-file="mise-gradle.xml">com.intellij.gradle</depends>
     <depends optional="true" config-file="mise-goland.xml">org.jetbrains.plugins.go</depends>
     <depends optional="true" config-file="mise-javascript.xml">JavaScript</depends>
+    <depends optional="true" config-file="mise-pythoncore.xml">com.intellij.modules.python</depends>
 </idea-plugin>


### PR DESCRIPTION
This was something I did last night, didn't get too far - the run configuration stuff isn't something I've played around with for pycharm before.

1. mise-pythoncore.xml doesn't work
2. Version pinning is terrible, it was to test.
3. Once this works, pythonid (closed source editor) should be straight forward.
4. In 2024.2 these are actually being unified.