### PR TITLE
fix: NodeRunConfiugrations is not working on IDEA

### DIFF
--- a/modules/products/nodejs/src/main/kotlin/com/github/l34130/mise/runconfig/NodeRunConfigurationExtension.kt
+++ b/modules/products/nodejs/src/main/kotlin/com/github/l34130/mise/runconfig/NodeRunConfigurationExtension.kt
@@ -37,7 +37,10 @@ class NodeRunConfigurationExtension : AbstractNodeRunConfigurationExtension() {
         environment: ExecutionEnvironment,
     ): NodeRunConfigurationLaunchSession? {
         val config = configuration as NodeJsRunConfiguration
-        config.envs.putAll(MiseCmd.loadEnv(config.workingDirectory))
+
+        val envs = config.envs.toMutableMap()
+        envs.putAll(MiseCmd.loadEnv(config.workingDirectory))
+        config.envs = envs
         return null
     }
 


### PR DESCRIPTION
## Description
- The reason was NodeJsRunConfigration's envs is immutable on IDEA (but it is mutable on WebStorm)
- Closes: #49