### PR TITLE
fix(deno): Path is configured as directory, not executable

### DIFF
--- a/modules/core/src/main/kotlin/com/github/l34130/mise/notifications/Notification.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/notifications/Notification.kt
@@ -4,8 +4,10 @@ import com.github.l34130.mise.icons.PluginIcons
 import com.intellij.notification.NotificationAction
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
+import com.intellij.openapi.options.Configurable
 import com.intellij.openapi.options.ShowSettingsUtil
 import com.intellij.openapi.project.Project
+import kotlin.reflect.KClass
 
 object Notification {
     fun notify(content: String, type: NotificationType, project: Project? = null) {
@@ -27,13 +29,37 @@ object Notification {
             .getNotificationGroup(NOTIFICATION_GROUP_ID)
             .createNotification(content.replace("\n", "<br>"), type)
             .addAction(
-                NotificationAction.createSimpleExpiring("Configure") {
+                NotificationAction.createSimple("Configure") {
                     ShowSettingsUtil.getInstance().showSettingsDialog(
                         project,
                         settingName
                     )
                 }
             )
+
+        notification.icon = PluginIcons.Default
+        notification.notify(project)
+    }
+
+    fun <T : Configurable> notifyWithLinkToSettings(
+        content: String,
+        configurableClass: KClass<T>,
+        type: NotificationType,
+        project: Project? = null,
+    ) {
+        val notification =
+            NotificationGroupManager
+                .getInstance()
+                .getNotificationGroup(NOTIFICATION_GROUP_ID)
+                .createNotification(content.replace("\n", "<br>"), type)
+                .addAction(
+                    NotificationAction.createSimple("Configure") {
+                        ShowSettingsUtil.getInstance().showSettingsDialog(
+                            project,
+                            configurableClass.java,
+                        )
+                    },
+                )
 
         notification.icon = PluginIcons.Default
         notification.notify(project)

--- a/modules/products/nodejs/src/main/kotlin/com/github/l34130/mise/deno/ProjectDenoSetup.kt
+++ b/modules/products/nodejs/src/main/kotlin/com/github/l34130/mise/deno/ProjectDenoSetup.kt
@@ -2,6 +2,7 @@ package com.github.l34130.mise.deno
 
 import com.github.l34130.mise.commands.MiseCmd
 import com.github.l34130.mise.notifications.Notification
+import com.intellij.deno.DenoConfigurable
 import com.intellij.deno.DenoSettings
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.actionSystem.AnAction
@@ -10,6 +11,8 @@ import com.intellij.openapi.application.WriteAction
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.StartupActivity
+import com.intellij.openapi.util.io.FileUtil
+import kotlin.io.path.Path
 
 class ProjectDenoSetup :
     AnAction(),
@@ -22,22 +25,33 @@ class ProjectDenoSetup :
         val denoSettings = project.service<DenoSettings>()
         val denoTools = MiseCmd.loadTools(project.basePath)["deno"] ?: return
 
+        if (denoTools.size > 1) {
+            Notification.notify("Multiple Deno SDKs found. Not setting any.", NotificationType.WARNING, project)
+            return
+        }
+
+        val denoTool = denoTools.first()
+        val absolutePathDenoDir =
+            Path(FileUtil.expandUserHome(denoTool.installPath), "bin", "deno")
+                .toAbsolutePath()
+                .normalize()
+                .toString()
+
         WriteAction.runAndWait<Throwable> {
-            for (tool in denoTools) {
-                tool.installPath
-
-                if (denoTools.size == 1) {
-                    denoSettings.setDenoPath(tool.installPath)
-                    Notification.notify(
-                        "Deno SDK set to ${tool.version} from ${tool.source.type}",
-                        NotificationType.INFORMATION,
-                        project,
-                    )
-                }
-            }
-
-            if (denoTools.size > 1) {
-                Notification.notify("Multiple Deno SDKs found. Not setting any.", NotificationType.WARNING, project)
+            try {
+                denoSettings.setDenoPath(absolutePathDenoDir)
+                Notification.notifyWithLinkToSettings(
+                    "Deno SDK set to deno@${denoTool.version} from ${denoTool.source.type}",
+                    DenoConfigurable::class,
+                    NotificationType.INFORMATION,
+                    project,
+                )
+            } catch (e: Exception) {
+                Notification.notify(
+                    "Failed to set Deno SDK: ${e.message}",
+                    NotificationType.ERROR,
+                    project,
+                )
             }
         }
     }


### PR DESCRIPTION
### Description
- Fix deno path is configured as directory, not executable
- https://github.com/134130/intellij-mise/issues/50#issuecomment-2466263265


![image](https://github.com/user-attachments/assets/e17ba144-3c6c-464a-bb24-e84d029e313c)

