### PR TITLE
fix: Show label on Run configuration that Settings overrides it

### DIFF
--- a/modules/core/src/main/kotlin/com/github/l34130/mise/run/MiseRunConfigurationSettingsEditor.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/run/MiseRunConfigurationSettingsEditor.kt
@@ -55,6 +55,7 @@ class MiseRunConfigurationSettingsEditor<T : RunConfigurationBase<*>>(
             USER_DATA_KEY,
             MiseRunConfigurationState(
                 useMiseDirEnv = myMiseDirEnvCb.isSelected,
+                miseProfile = myMiseProfileTf.text,
             ),
         )
     }
@@ -63,6 +64,7 @@ class MiseRunConfigurationSettingsEditor<T : RunConfigurationBase<*>>(
         val userData = config.getCopyableUserData(USER_DATA_KEY) ?: return
 
         myMiseDirEnvCb.isSelected = userData.useMiseDirEnv
+        myMiseProfileTf.text = userData.miseProfile
     }
 
     companion object {
@@ -74,7 +76,12 @@ class MiseRunConfigurationSettingsEditor<T : RunConfigurationBase<*>>(
             element: Element,
         ) {
             val miseDirEnvCb = element.getAttributeValue("myMiseDirEnvCb")?.toBoolean() ?: false
-            val state = MiseRunConfigurationState(useMiseDirEnv = miseDirEnvCb)
+            val miseProfile = element.getAttributeValue("myMiseProfileTf") ?: ""
+            val state =
+                MiseRunConfigurationState(
+                    useMiseDirEnv = miseDirEnvCb,
+                    miseProfile = miseProfile,
+                )
             runConfiguration.putCopyableUserData(USER_DATA_KEY, state)
         }
 
@@ -85,6 +92,7 @@ class MiseRunConfigurationSettingsEditor<T : RunConfigurationBase<*>>(
             val userData = runConfiguration.getCopyableUserData(USER_DATA_KEY) ?: return
 
             element.setAttribute("myMiseDirEnvCb", userData.useMiseDirEnv.toString())
+            element.setAttribute("myMiseProfileTf", userData.miseProfile)
         }
 
         fun getMiseRunConfigurationState(configuration: RunConfigurationBase<*>): MiseRunConfigurationState? =

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/run/MiseRunConfigurationSettingsEditor.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/run/MiseRunConfigurationSettingsEditor.kt
@@ -25,16 +25,18 @@ class MiseRunConfigurationSettingsEditor<T : RunConfigurationBase<*>>(
 
     override fun createEditor(): JComponent {
         val service = MiseSettings.getService(project)
-        myMiseDirEnvCb.isSelected = service.state.useMiseDirEnv
-        myMiseProfileTf.text = service.state.miseProfile
+        if (service.state.useMiseDirEnv) {
+            myMiseDirEnvCb.isSelected = true
+            myMiseProfileTf.text = service.state.miseProfile
+        }
 
         return JPanel(BorderLayout()).apply {
             add(
                 panel {
                     row {
-                        cell(myMiseDirEnvCb).comment(
-                            "Load environment variables from mise configuration file(s)",
-                        )
+                        cell(myMiseDirEnvCb)
+                            .comment("Load environment variables from mise configuration file(s)")
+                            .enabled(!service.state.useMiseDirEnv)
                     }
                     row("Profile: ") {
                         cell(myMiseProfileTf)
@@ -44,6 +46,12 @@ class MiseRunConfigurationSettingsEditor<T : RunConfigurationBase<*>>(
                             ).columns(COLUMNS_LARGE)
                             .focused()
                             .resizableColumn()
+                            .enabled(!service.state.useMiseDirEnv)
+                    }
+                    row {
+                        cell(JPanel())
+                            .comment("<icon src='AllIcons.General.ShowWarning'> Using the configuration in Settings")
+                            .visible(service.state.useMiseDirEnv)
                     }
                 },
             )
@@ -69,7 +77,7 @@ class MiseRunConfigurationSettingsEditor<T : RunConfigurationBase<*>>(
 
     companion object {
         const val EDITOR_TITLE: String = "Mise"
-        val SERIALIZATION_ID: String = Companion::class.qualifiedName!!
+        val SERIALIZATION_ID: String = MiseRunConfigurationSettingsEditor::class.java.name
 
         fun readExternal(
             runConfiguration: RunConfigurationBase<*>,

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/settings/MiseConfigurable.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/settings/MiseConfigurable.kt
@@ -23,6 +23,7 @@ class MiseConfigurable(
         val service = MiseSettings.getService(project)
 
         myMiseDirEnvCb.isSelected = service.state.useMiseDirEnv
+        myMiseProfileTf.text = service.state.miseProfile
 
         return JPanel(BorderLayout()).apply {
             add(
@@ -56,6 +57,7 @@ class MiseConfigurable(
         if (isModified) {
             val service = MiseSettings.getService(project)
             service.state.useMiseDirEnv = myMiseDirEnvCb.isSelected
+            service.state.miseProfile = myMiseProfileTf.text
         }
     }
 

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/settings/MiseConfigurable.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/settings/MiseConfigurable.kt
@@ -3,7 +3,6 @@ package com.github.l34130.mise.settings
 import com.intellij.openapi.options.SearchableConfigurable
 import com.intellij.openapi.project.Project
 import com.intellij.ui.components.JBCheckBox
-import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBTextField
 import com.intellij.ui.dsl.builder.COLUMNS_LARGE
 import com.intellij.ui.dsl.builder.columns
@@ -41,11 +40,6 @@ class MiseConfigurable(
                             ).columns(COLUMNS_LARGE)
                             .focused()
                             .resizableColumn()
-                    }
-                    row {
-                        cell(
-                            JBLabel("These settings are used as default values and may be overridden by run configuration settings."),
-                        )
                     }
                 },
             )

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/settings/MiseSettings.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/settings/MiseSettings.kt
@@ -21,9 +21,7 @@ data class MiseState(
 
 @Service(Service.Level.PROJECT)
 @State(name = "com.github.l34130.mise.settings.MiseSettings", storages = [Storage("mise.xml")])
-class MiseSettings(
-    private val project: Project,
-) : PersistentStateComponent<MiseState> {
+class MiseSettings : PersistentStateComponent<MiseState> {
     private var state = MiseState()
 
     override fun getState() = state


### PR DESCRIPTION
## Description
- Add label and disable when settings' mise is enabled.
- And minor fixes: new fields are not applying