### PR TITLE
fix!: Change minimum support version to 2023.3+

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,12 @@ jobs:
       changelog: ${{ steps.properties.outputs.changelog }}
       pluginVerifierHomeDir: ${{ steps.properties.outputs.pluginVerifierHomeDir }}
     steps:
+      # Free GitHub Actions Environment Disk Space
+      - name: Maximize Build Space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          large-packages: false
 
       # Check out the current repository
       - name: Fetch Sources

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,12 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      # Free GitHub Actions Environment Disk Space
+      - name: Maximize Build Space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          large-packages: false
 
       # Check out the current repository
       - name: Fetch Sources

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -104,7 +104,7 @@ intellijPlatform {
 
     pluginVerification {
         ides {
-//            recommended()
+            recommended()
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,8 +7,8 @@ pluginRepositoryUrl = https://github.com/134130/intellij-mise
 pluginVersion=2.6.2
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-pluginSinceBuild = 223
-platformVersion = 2022.3.3
+pluginSinceBuild=233
+platformVersion=2023.3.6
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22

--- a/modules/core/build.gradle.kts
+++ b/modules/core/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
         create(IntelliJPlatformType.IntellijIdeaCommunity, properties("platformVersion"), false)
 
         bundledPlugin("com.intellij.java")
+        bundledPlugin("org.jetbrains.plugins.terminal")
 
         instrumentationTools()
     }

--- a/modules/core/build.gradle.kts
+++ b/modules/core/build.gradle.kts
@@ -16,6 +16,8 @@ dependencies {
         bundledPlugin("com.intellij.java")
         bundledPlugin("org.jetbrains.plugins.terminal")
 
+        jetbrainsRuntime()
+
         instrumentationTools()
     }
 }

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/command/MiseRunTaskOnTerminalAction.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/command/MiseRunTaskOnTerminalAction.kt
@@ -3,11 +3,9 @@ package com.github.l34130.mise.core.command
 import com.github.l34130.mise.core.util.TerminalUtils
 import com.intellij.icons.AllIcons
 import com.intellij.openapi.actionSystem.AnActionEvent
-import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.project.Project
-import org.jetbrains.plugins.terminal.TerminalView
 
 class MiseRunTaskOnTerminalAction(
     private val taskName: String,
@@ -35,8 +33,6 @@ class MiseRunTaskOnTerminalAction(
             taskName: String,
             profile: String? = null,
         ) {
-            project.service<TerminalView>().createLocalShellWidget(project.basePath, taskName)
-
             val command =
                 buildString {
                     append("mise run")

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/run/MiseRunConfigurationSettingsEditor.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/run/MiseRunConfigurationSettingsEditor.kt
@@ -59,9 +59,8 @@ class MiseRunConfigurationSettingsEditor<T : RunConfigurationBase<*>>(
                     row {
                         icon(AllIcons.General.ShowWarning)
                         label("Using the configuration in Settings / Tools / Mise Settings")
-                            .visible(isOverridden)
                             .bold()
-                    }
+                    }.visible(isOverridden)
                 },
             )
         }

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/setup/AbstractProjectSdkSetup.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/setup/AbstractProjectSdkSetup.kt
@@ -12,20 +12,22 @@ import com.intellij.openapi.application.WriteAction
 import com.intellij.openapi.components.service
 import com.intellij.openapi.options.Configurable
 import com.intellij.openapi.options.ShowSettingsUtil
+import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.startup.StartupActivity
+import com.intellij.openapi.startup.ProjectActivity
 import com.intellij.openapi.util.io.FileUtil
 import kotlin.reflect.KClass
 
 abstract class AbstractProjectSdkSetup :
     DumbAwareAction(),
-    StartupActivity.DumbAware {
+    ProjectActivity,
+    DumbAware {
     final override fun actionPerformed(e: AnActionEvent) {
         e.project?.let { configureSdk(it, true) }
     }
 
-    final override fun runActivity(project: Project) {
+    override suspend fun execute(project: Project) {
         configureSdk(project, false)
     }
 

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/toolwindow/MiseTreeToolWindow.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/toolwindow/MiseTreeToolWindow.kt
@@ -125,13 +125,6 @@ class MiseTreeToolWindow(
     override fun dispose() {
     }
 
-    override fun getData(dataId: String): Any? =
-        when {
-//            ExplorerTreeToolWindowDataKeys.SELECTED_NODES.`is`(dataId) -> getSelectedNodes<AbstractTreeNode<*>>()
-//            ExplorerTreeToolWindowDataKeys.REFRESH_CALLBACK.`is`(dataId) ->
-            else -> null
-        }
-
     private inline fun <reified T : AbstractTreeNode<*>> getSelectedNodesSameType(): List<T>? {
         val selectedNodes = getSelectedNodes<T>()
         if (selectedNodes.isEmpty()) {

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/util/TerminalUtils.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/util/TerminalUtils.kt
@@ -4,7 +4,7 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.ToolWindowManager
 import org.jetbrains.plugins.terminal.TerminalToolWindowFactory
-import org.jetbrains.plugins.terminal.TerminalView
+import org.jetbrains.plugins.terminal.TerminalToolWindowManager
 
 object TerminalUtils {
     fun executeCommand(
@@ -12,7 +12,8 @@ object TerminalUtils {
         command: String,
         tabName: String? = null,
     ) {
-        val widget = project.service<TerminalView>().createLocalShellWidget(project.basePath, tabName ?: "Mise")
+        val widget =
+            project.service<TerminalToolWindowManager>().createLocalShellWidget(project.basePath, tabName ?: "Mise")
 
         project
             .service<ToolWindowManager>()

--- a/modules/products/goland/build.gradle.kts
+++ b/modules/products/goland/build.gradle.kts
@@ -16,6 +16,8 @@ dependencies {
 
         bundledPlugin("org.jetbrains.plugins.go")
 
+        jetbrainsRuntime()
+
         instrumentationTools()
     }
 }

--- a/modules/products/gradle/build.gradle.kts
+++ b/modules/products/gradle/build.gradle.kts
@@ -17,6 +17,8 @@ dependencies {
 
         bundledPlugins("com.intellij.java", "com.intellij.gradle")
 
+        jetbrainsRuntime()
+
         instrumentationTools()
     }
 }

--- a/modules/products/idea/build.gradle.kts
+++ b/modules/products/idea/build.gradle.kts
@@ -16,6 +16,8 @@ dependencies {
 
         bundledPlugin("com.intellij.java")
 
+        jetbrainsRuntime()
+
         instrumentationTools()
     }
 }

--- a/modules/products/nodejs/build.gradle.kts
+++ b/modules/products/nodejs/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
         create(IntelliJPlatformType.WebStorm, properties("platformVersion"))
 
         bundledPlugins("JavaScript", "NodeJS")
-        plugins("deno:223.7571.4")
+        plugins("deno:233.6745.297")
 
         instrumentationTools()
     }

--- a/modules/products/nodejs/build.gradle.kts
+++ b/modules/products/nodejs/build.gradle.kts
@@ -17,6 +17,8 @@ dependencies {
         bundledPlugins("JavaScript", "NodeJS")
         plugins("deno:233.6745.297")
 
+        jetbrainsRuntime()
+
         instrumentationTools()
     }
 }

--- a/modules/products/rider/build.gradle.kts
+++ b/modules/products/rider/build.gradle.kts
@@ -14,6 +14,8 @@ dependencies {
     intellijPlatform {
         create(IntelliJPlatformType.Rider, properties("platformVersion"))
 
+        jetbrainsRuntime()
+
         instrumentationTools()
     }
 }

--- a/modules/products/rider/src/main/kotlin/com/github/l34130/mise/rider/run/RiderPatchCommandLineExtension.kt
+++ b/modules/products/rider/src/main/kotlin/com/github/l34130/mise/rider/run/RiderPatchCommandLineExtension.kt
@@ -3,6 +3,7 @@ package com.github.l34130.mise.rider.run
 import com.github.l34130.mise.core.command.MiseCommandLine
 import com.github.l34130.mise.core.setting.MiseSettings
 import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.process.ProcessInfo
 import com.intellij.execution.process.ProcessListener
 import com.intellij.openapi.project.Project
 import com.jetbrains.rd.util.lifetime.Lifetime
@@ -17,6 +18,7 @@ class RiderPatchCommandLineExtension : PatchCommandLineExtension {
     override fun patchDebugCommandLine(
         lifetime: Lifetime,
         workerRunInfo: WorkerRunInfo,
+        processInfo: ProcessInfo?,
         project: Project,
     ): Promise<WorkerRunInfo> {
         patchCommandLine(workerRunInfo.commandLine, project)

--- a/modules/products/toml/build.gradle.kts
+++ b/modules/products/toml/build.gradle.kts
@@ -16,6 +16,8 @@ dependencies {
 
         bundledPlugin("org.toml.lang")
 
+        jetbrainsRuntime()
+
         instrumentationTools()
     }
 }

--- a/modules/products/toml/src/main/kotlin/com/github/l34130/mise/toml/editor/MiseRunLineMarkerProvider.kt
+++ b/modules/products/toml/src/main/kotlin/com/github/l34130/mise/toml/editor/MiseRunLineMarkerProvider.kt
@@ -3,7 +3,6 @@ package com.github.l34130.mise.toml.editor
 import com.github.l34130.mise.core.command.MiseRunTaskOnTerminalAction
 import com.github.l34130.mise.core.setting.MiseSettings
 import com.intellij.execution.lineMarker.RunLineMarkerContributor
-import com.intellij.icons.AllIcons
 import com.intellij.openapi.components.service
 import com.intellij.psi.PsiElement
 import com.intellij.psi.impl.source.tree.LeafPsiElement
@@ -24,11 +23,8 @@ class MiseRunLineMarkerProvider : RunLineMarkerContributor() {
 
         val miseSettings = element.project.service<MiseSettings>()
         val profile = miseSettings.state.miseProfile
-        return Info(
-            AllIcons.Actions.Execute,
-            { "Run Mise task: $taskName" },
-            MiseRunTaskOnTerminalAction(taskName, profile),
-        )
+
+        return Info(MiseRunTaskOnTerminalAction(taskName, profile))
     }
 
     private fun getTaskInfo(element: LeafPsiElement): String? {

--- a/src/main/resources/META-INF/mise-deno.xml
+++ b/src/main/resources/META-INF/mise-deno.xml
@@ -1,4 +1,4 @@
-<idea-plugin>
+<idea-plugin require-restart="false">
     <extensions defaultExtensionNs="com.intellij">
         <postStartupActivity implementation="com.github.l34130.mise.nodejs.deno.ProjectDenoSetup"/>
     </extensions>

--- a/src/main/resources/META-INF/mise-goland.xml
+++ b/src/main/resources/META-INF/mise-goland.xml
@@ -1,4 +1,4 @@
-<idea-plugin>
+<idea-plugin require-restart="false">
     <extensions defaultExtensionNs="com.intellij">
         <postStartupActivity implementation="com.github.l34130.mise.goland.go.ProjectGoSdkSetup"/>
     </extensions>

--- a/src/main/resources/META-INF/mise-gradle.xml
+++ b/src/main/resources/META-INF/mise-gradle.xml
@@ -1,4 +1,4 @@
-<idea-plugin>
+<idea-plugin require-restart="false">
     <extensions defaultExtensionNs="org.jetbrains.plugins.gradle">
         <executionEnvironmentProvider implementation="com.github.l34130.mise.gradle.run.GradleEnvironmentProvider"
                                       order="first"/>

--- a/src/main/resources/META-INF/mise-idea.xml
+++ b/src/main/resources/META-INF/mise-idea.xml
@@ -1,4 +1,4 @@
-<idea-plugin>
+<idea-plugin require-restart="false">
     <extensions defaultExtensionNs="com.intellij">
         <postStartupActivity implementation="com.github.l34130.mise.idea.jdk.ProjectJdkSetup"/>
         <runConfigurationExtension implementation="com.github.l34130.mise.idea.run.IdeaRunConfigurationExtension"

--- a/src/main/resources/META-INF/mise-javascript.xml
+++ b/src/main/resources/META-INF/mise-javascript.xml
@@ -1,4 +1,4 @@
-<idea-plugin>
+<idea-plugin require-restart="false">
     <depends optional="true" config-file="mise-nodejs.xml">NodeJS</depends>
     <depends optional="true" config-file="mise-deno.xml">deno</depends>
 </idea-plugin>

--- a/src/main/resources/META-INF/mise-nodejs.xml
+++ b/src/main/resources/META-INF/mise-nodejs.xml
@@ -1,4 +1,4 @@
-<idea-plugin>
+<idea-plugin require-restart="false">
     <extensions defaultExtensionNs="com.intellij">
         <postStartupActivity implementation="com.github.l34130.mise.nodejs.node.ProjectNodeSetup"/>
     </extensions>

--- a/src/main/resources/META-INF/mise-rider.xml
+++ b/src/main/resources/META-INF/mise-rider.xml
@@ -1,4 +1,4 @@
-<idea-plugin>
+<idea-plugin require-restart="false">
     <extensions defaultExtensionNs="com.intellij">
         <rider.patchCommandLine implementation="com.github.l34130.mise.rider.run.RiderPatchCommandLineExtension"/>
     </extensions>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,5 +1,5 @@
 <!-- Plugin Configuration File. Read more: https://plugins.jetbrains.com/docs/intellij/plugin-configuration-file.html -->
-<idea-plugin url="https://github.com/l34130/intellij-mise">
+<idea-plugin url="https://github.com/l34130/intellij-mise" require-restart="false">
     <id>com.github.l34130.mise</id>
     <name>Mise</name>
     <vendor>134130</vendor>


### PR DESCRIPTION
## Description
- There is many deprecated APIs
- To support 2024.3+, We need to upgrade the obsoleted APIs.
- Change the minimum support version from 2022.3+ to 2023.3+

## Links
- Resolves #85
- Resolves #91
- Resolves #92