### PR TITLE
fix: stacktrace for error reporter is too short

### DIFF
--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/MiseErrorReportSubmitter.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/MiseErrorReportSubmitter.kt
@@ -77,7 +77,7 @@ class MiseErrorReportSubmitter : ErrorReportSubmitter() {
                             appendLine("### Stacktrace")
                             appendLine("```")
                             appendLine(throwable.message)
-                            appendLine(throwable.stackTrace.joinToString("\n").take(25))
+                            appendLine(throwable.stackTrace.take(25).joinToString("\n"))
                             appendLine("```")
 
                             appendLine()


### PR DESCRIPTION
We're slicing the stack trace because we can't open pull requests if the content is too long.

However, we're currently deleting so many stack traces that the meaning is faded, and I don't think that's the intended behavior.

Fix the code correctly (as may intended)