### PR TITLE
feat: Add MiseTomlService and MiseTaskService

### DIFF
--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/MiseStartupActivity.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/MiseStartupActivity.kt
@@ -1,0 +1,18 @@
+package com.github.l34130.mise.core
+
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.ProjectActivity
+
+internal class MiseStartupActivity :
+    ProjectActivity,
+    DumbAware {
+    override suspend fun execute(project: Project) {
+        val tomlService = project.service<MiseTomlService>()
+        val taskService = project.service<MiseTaskService>()
+
+        tomlService.refresh().get()
+        taskService.refresh().get()
+    }
+}

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/MiseTaskService.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/MiseTaskService.kt
@@ -1,40 +1,78 @@
 package com.github.l34130.mise.core
 
+import com.github.l34130.mise.core.lang.psi.MiseTomlFile
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ReadAction
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
 import com.intellij.openapi.project.BaseProjectDirectories.Companion.getBaseDirectories
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.findPsiFile
 import com.intellij.openapi.vfs.resolveFromRootOrRelative
+import com.intellij.util.concurrency.SequentialTaskExecutor
 import com.intellij.util.containers.addIfNotNull
+import org.jetbrains.concurrency.CancellablePromise
+import java.util.concurrent.ConcurrentHashMap
 
-class MiseTaskService {
-    companion object {
-        fun getFileTaskDirectories(project: Project): List<VirtualFile> {
-            val result = mutableListOf<VirtualFile>()
-            for (baseDir in project.getBaseDirectories()) {
-                result.addIfNotNull(baseDir.resolveFromRootOrRelative("mise-tasks")?.takeIf { it.isDirectory })
-                result.addIfNotNull(baseDir.resolveFromRootOrRelative(".mise-tasks")?.takeIf { it.isDirectory })
-                result.addIfNotNull(baseDir.resolveFromRootOrRelative("mise/tasks")?.takeIf { it.isDirectory })
-                result.addIfNotNull(baseDir.resolveFromRootOrRelative(".mise/tasks")?.takeIf { it.isDirectory })
-                result.addIfNotNull(baseDir.resolveFromRootOrRelative(".config/mise/tasks")?.takeIf { it.isDirectory })
-            }
-            return result
+@Service(Service.Level.PROJECT)
+class MiseTaskService(
+    val project: Project,
+) : Disposable {
+    private val taskConfigDirectories: MutableSet<VirtualFile> = ConcurrentHashMap.newKeySet<VirtualFile>()
+
+    private val executor = SequentialTaskExecutor.createSequentialApplicationPoolExecutor("MiseTaskService")
+
+    init {
+        project.messageBus.connect(this).let {
+            it.subscribe(
+                MiseTomlFileVfsListener.MISE_TOML_CHANGED,
+                Runnable {
+                    taskConfigDirectories.clear()
+                    loadFileTaskDirectories()
+                },
+            )
         }
     }
 
-//            val miseTomlFiles = MiseTomlService.getMiseTomlFiles(project)
-// TODO: Implement MiseToml `task_config` support
-//                ReadAction
-//                    .run<Throwable> {
-//                        for (miseToml in miseTomlFiles) {
-//                            val psiFile = miseToml.findPsiFile(project) as? MiseTomlFile ?: continue
-//
-//                            val taskConfig =
-//                                psiFile
-//                                    .childrenOfType<TomlTable>()
-//                                    .firstOrNull { it.header.key?.textMatches("task_config") == true } ?: continue
-//
-//                            val taskDir = taskConfig.getValueWithKey("dir")?.stringValue ?: continue
-//                            result.addIfNotNull(baseDir.resolveFromRootOrRelative(taskDir))
-//                        }
-//                    }
+    fun getFileTaskDirectories(): Set<VirtualFile> = taskConfigDirectories
+
+    fun refresh(): CancellablePromise<Unit> {
+        taskConfigDirectories.clear()
+        return loadFileTaskDirectories()
+    }
+
+    private fun loadFileTaskDirectories(): CancellablePromise<Unit> =
+        ReadAction
+            .nonBlocking<Unit> {
+                val result = mutableListOf<VirtualFile>()
+                for (baseDir in project.getBaseDirectories()) {
+                    result.addIfNotNull(baseDir.resolveFromRootOrRelative("mise-tasks")?.takeIf { it.isDirectory })
+                    result.addIfNotNull(baseDir.resolveFromRootOrRelative(".mise-tasks")?.takeIf { it.isDirectory })
+                    result.addIfNotNull(baseDir.resolveFromRootOrRelative("mise/tasks")?.takeIf { it.isDirectory })
+                    result.addIfNotNull(baseDir.resolveFromRootOrRelative(".mise/tasks")?.takeIf { it.isDirectory })
+                    result.addIfNotNull(baseDir.resolveFromRootOrRelative(".config/mise/tasks")?.takeIf { it.isDirectory })
+
+                    val miseTomlFiles = project.service<MiseTomlService>().getMiseTomlFiles()
+                    for (miseToml in miseTomlFiles) {
+                        val psiFile = miseToml.findPsiFile(project) as? MiseTomlFile ?: continue
+
+                        val taskConfig = MiseTomlFile.TaskConfig.resolveOrNull(psiFile) ?: continue
+                        val taskTomlOrDirs = taskConfig.includes ?: continue
+
+                        for (taskTomlOrDir in taskTomlOrDirs) {
+                            val file = baseDir.resolveFromRootOrRelative(taskTomlOrDir) ?: continue
+                            if (file.isDirectory) {
+                                result.addIfNotNull(file)
+                            }
+                        }
+                    }
+                }
+
+                taskConfigDirectories.addAll(result)
+            }.expireWith(this)
+            .submit(executor)
+
+    override fun dispose() {
+    }
 }

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/MiseTomlFileVfsListener.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/MiseTomlFileVfsListener.kt
@@ -1,0 +1,110 @@
+package com.github.l34130.mise.core
+
+import com.github.l34130.mise.core.lang.MiseTomlFileType
+import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer
+import com.intellij.openapi.editor.EditorFactory
+import com.intellij.openapi.editor.ex.EditorEx
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.ZipperUpdater
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.VirtualFileContentsChangedAdapter
+import com.intellij.openapi.vfs.VirtualFileManager
+import com.intellij.openapi.vfs.impl.BulkVirtualFileListenerAdapter
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiManager
+import com.intellij.psi.PsiTreeAnyChangeAbstractAdapter
+import com.intellij.util.Alarm
+import com.intellij.util.application
+import com.intellij.util.concurrency.SequentialTaskExecutor
+import com.intellij.util.messages.MessageBusConnection
+import com.intellij.util.messages.Topic
+import kotlinx.coroutines.Runnable
+import java.util.concurrent.ConcurrentHashMap
+
+class MiseTomlFileVfsListener private constructor(
+    updater: MiseLocalIndexUpdater,
+) : BulkVirtualFileListenerAdapter(
+        object : VirtualFileContentsChangedAdapter() {
+            override fun onFileChange(fileOrDirectory: VirtualFile) {
+                updater.onFileChange(fileOrDirectory)
+            }
+
+            override fun onBeforeFileChange(fileOrDirectory: VirtualFile) {}
+        },
+    ) {
+    companion object {
+        val MISE_TOML_CHANGED = Topic.create("MISE_TOML_CHANGED", Runnable::class.java)
+
+        fun startListening(
+            project: Project,
+            service: MiseTomlService,
+            connection: MessageBusConnection,
+        ) {
+            val updater = MiseLocalIndexUpdater(project, service)
+            connection.subscribe(VirtualFileManager.VFS_CHANGES, MiseTomlFileVfsListener(updater))
+            PsiManager.getInstance(project).addPsiTreeChangeListener(
+                object : PsiTreeAnyChangeAbstractAdapter() {
+                    override fun onChange(file: PsiFile?) {
+                        if (file != null) {
+                            updater.onFileChange(file.viewProvider.virtualFile)
+                        }
+                    }
+                },
+                service,
+            )
+        }
+    }
+
+    class MiseLocalIndexUpdater(
+        val project: Project,
+        val service: MiseTomlService,
+    ) {
+        private val updater = ZipperUpdater(200, Alarm.ThreadToUse.POOLED_THREAD, application)
+        private val taskExecutor = SequentialTaskExecutor.createSequentialApplicationPoolExecutor("MiseLocalIndexVfsListener")
+        private val dirtyTomlFiles: MutableSet<VirtualFile> = ConcurrentHashMap.newKeySet<VirtualFile>()
+        private val runnable =
+            Runnable {
+                if (project.isDisposed) return@Runnable
+                val scope = HashSet(dirtyTomlFiles)
+                if (scope.any { f: VirtualFile -> service.possiblyHasReference(f.name) }) {
+                    project.messageBus.syncPublisher(MISE_TOML_CHANGED).run()
+                    dirtyTomlFiles.removeAll(scope)
+                }
+
+                val analyzer = DaemonCodeAnalyzer.getInstance(project)
+                val psiManager = PsiManager.getInstance(project)
+                val editors = EditorFactory.getInstance().allEditors
+                for (editor in editors) {
+                    if (editor !is EditorEx || editor.project != project) continue
+
+                    val file = editor.virtualFile
+                    if (file == null || !file.isValid) continue
+
+//                    val schemaFiles = service.getSchemasForFile(file, false, true)
+//                    if (schemaFiles.contains { finalScope::contains }) {
+//                        ReadAction
+//                            .nonBlocking<Unit>(Callable { restartAnalyzer(analyzer, psiManager, file) })
+//                            .expireWith(service)
+//                            .submit(taskExecutor)
+                }
+            }
+
+        fun onFileChange(file: VirtualFile) {
+            if (MiseTomlFileType.isMiseTomlFile(project, file)) {
+                dirtyTomlFiles.add(file)
+                updater.queue(runnable)
+            }
+        }
+
+        private fun restartAnalyzer(
+            analyzer: DaemonCodeAnalyzer,
+            psiManager: PsiManager,
+            file: VirtualFile,
+        ) {
+            if (psiManager.isDisposed) return
+            if (!file.isValid) return
+            val psiFile = psiManager.findFile(file) ?: return
+            analyzer.restart(psiFile)
+        }
+    }
+}

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/MiseTomlService.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/MiseTomlService.kt
@@ -1,0 +1,99 @@
+package com.github.l34130.mise.core
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ReadAction
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.project.BaseProjectDirectories.Companion.getBaseDirectories
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.resolveFromRootOrRelative
+import com.intellij.util.concurrency.SequentialTaskExecutor
+import com.intellij.util.containers.addIfNotNull
+import com.jetbrains.rd.util.ConcurrentHashMap
+import org.jetbrains.concurrency.CancellablePromise
+import java.util.concurrent.atomic.AtomicLong
+
+@Service(Service.Level.PROJECT)
+class MiseTomlService(
+    val project: Project,
+) : Disposable {
+    private val files: MutableSet<VirtualFile> = ConcurrentHashMap.newKeySet<VirtualFile>()
+    private val refs: MutableSet<String> = ConcurrentHashMap.newKeySet<String>()
+    private val anyChangeCount = AtomicLong(0)
+
+    private val executor = SequentialTaskExecutor.createSequentialApplicationPoolExecutor("MiseTomlService")
+
+    init {
+        project.messageBus.connect(this).let {
+            it.subscribe(
+                MiseTomlFileVfsListener.MISE_TOML_CHANGED,
+                Runnable {
+                    refs.clear()
+                    anyChangeCount.incrementAndGet()
+                },
+            )
+            MiseTomlFileVfsListener.startListening(project, this, it)
+        }
+    }
+
+//    override fun getModificationCount(): Long = anyChangeCount.get()
+
+    fun registerRef(ref: String) {
+        val index = ref.lastIndexOfAny(listOf("\\", "/"))
+        if (index >= 0) {
+            refs.add(ref.substring(index + 1))
+        }
+    }
+
+    fun possiblyHasReference(ref: String) = refs.contains(ref)
+
+    fun getMiseTomlFiles(): Set<VirtualFile> = files
+
+    fun refresh(): CancellablePromise<Unit> {
+        files.clear()
+        return loadMiseTomlFiles()
+    }
+
+    private fun loadMiseTomlFiles(): CancellablePromise<Unit> =
+        ReadAction
+            .nonBlocking<Unit> {
+                val result = mutableListOf<VirtualFile>()
+
+                for (baseDir in project.getBaseDirectories()) {
+                    for (child in baseDir.children) {
+                        if (child.isDirectory) {
+                            // mise/config.toml or .mise/config.toml
+                            if (child.name == "mise" || child.name == ".mise") {
+                                result.addIfNotNull(child.resolveFromRootOrRelative("config.toml"))
+                            }
+
+                            if (child.name == ".config") {
+                                // .config/mise.toml
+                                result.addIfNotNull(child.resolveFromRootOrRelative("mise.toml"))
+                                // .config/mise/config.toml
+                                result.addIfNotNull(child.resolveFromRootOrRelative("config.toml"))
+                                // .config/mise/conf.d/*.toml
+                                result.addAll(child.resolveFromRootOrRelative("conf.d")?.children.orEmpty())
+                            }
+                        } else {
+                            // mise.local.toml, mise.toml, .mise.local.toml, .mise.toml
+                            if (child.name.matches(MISE_TOML_NAME_REGEX)) {
+                                result.add(child)
+                            }
+                        }
+                    }
+                }
+
+                files.addAll(result)
+            }.expireWith(this)
+            .submit(executor)
+
+    override fun dispose() {
+    }
+
+    companion object {
+        private val MISE_TOML_NAME_REGEX = "^\\.?mise\\.(\\w+\\.)?toml$".toRegex()
+
+        fun getInstance(project: Project): MiseTomlService = project.getService(MiseTomlService::class.java)
+    }
+}

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/lang/MiseTomlFileType.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/lang/MiseTomlFileType.kt
@@ -1,6 +1,9 @@
 package com.github.l34130.mise.core.lang
 
 import com.intellij.openapi.fileTypes.LanguageFileType
+import com.intellij.openapi.project.BaseProjectDirectories.Companion.getBaseDirectories
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
 import org.toml.lang.TomlLanguage
 import org.toml.lang.psi.TomlFileType
 import javax.swing.Icon
@@ -13,4 +16,54 @@ object MiseTomlFileType : LanguageFileType(TomlLanguage) {
     override fun getDefaultExtension(): String = "toml"
 
     override fun getIcon(): Icon = TomlFileType.icon
+
+    fun isMiseTomlFile(
+        project: Project,
+        file: VirtualFile,
+    ): Boolean {
+        if (file.fileType != this) return false
+
+        if (file.name in listOf("mise.local.toml", ".mise.local.toml", "mise.toml", ".mise.toml") ||
+            file.name.matches("^mise\\.(\\w+\\.)?toml$".toRegex())
+        ) {
+            return file.parent?.isProjectBaseDir(project) == true
+        }
+
+        if (file.name == "config.toml") {
+            if (file.isParentName("mise") || file.isParentName(".mise")) {
+                return file.parentOf(2)?.isProjectBaseDir(project) == true
+            }
+        }
+
+        if (file.name == "mise.toml" && file.isParentName(".config")) {
+            return file.parentOf(2)?.isProjectBaseDir(project) == true
+        }
+        if (file.name == "config.toml" && file.isParentName("mise", ".config")) {
+            return file.parentOf(3)?.isProjectBaseDir(project) == true
+        }
+        if (file.extension == "toml" && file.isParentName("conf.d", "mise", ".config")) {
+            if (project.getBaseDirectories().contains(file.parent?.parent)) return true
+        }
+
+        return false
+    }
+
+    private fun VirtualFile.isParentName(vararg names: String): Boolean {
+        var parent = this
+        for (i in names.indices.reversed()) {
+            parent = parent.parent ?: return false
+            if (parent.name != names[i]) return false
+        }
+        return true
+    }
+
+    private fun VirtualFile.parentOf(depth: Int = 1): VirtualFile? {
+        var parent = this
+        repeat(depth) {
+            parent = parent.parent ?: return null
+        }
+        return parent
+    }
+
+    private fun VirtualFile.isProjectBaseDir(project: Project): Boolean = project.getBaseDirectories().contains(this)
 }

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/lang/psi/MiseTomlFile.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/lang/psi/MiseTomlFile.kt
@@ -3,7 +3,10 @@ package com.github.l34130.mise.core.lang.psi
 import com.github.l34130.mise.core.lang.MiseTomlFileType
 import com.intellij.extapi.psi.PsiFileBase
 import com.intellij.psi.FileViewProvider
+import com.intellij.psi.util.childrenOfType
 import org.toml.lang.TomlLanguage
+import org.toml.lang.psi.TomlArray
+import org.toml.lang.psi.TomlTable
 
 class MiseTomlFile(
     viewProvider: FileViewProvider,
@@ -11,4 +14,18 @@ class MiseTomlFile(
     override fun getFileType() = MiseTomlFileType
 
     override fun toString() = "Mise Toml File"
+
+    class TaskConfig(
+        origin: TomlTable,
+    ) : TomlTable by origin {
+        val includes: List<String>?
+            get() = (getValueWithKey("includes") as? TomlArray)?.elements?.mapNotNull { it.stringValue }
+
+        companion object {
+            fun resolveOrNull(file: MiseTomlFile): TaskConfig? {
+                val table = file.childrenOfType<TomlTable>().firstOrNull { it.header.key?.textMatches("task_config") == true }
+                return table?.let { TaskConfig(it) }
+            }
+        }
+    }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -40,6 +40,8 @@
     </extensions>
 
     <extensions defaultExtensionNs="com.intellij">
+        <postStartupActivity implementation="com.github.l34130.mise.core.MiseStartupActivity"/>
+
         <projectConfigurable id="com.github.l34130.mise.core.setting.MiseConfigurable"
                              instance="com.github.l34130.mise.core.setting.MiseConfigurable"
                              groupId="tools"


### PR DESCRIPTION
Closes: #137

- `MiseTomlService` will indexes the mise config (toml) files.
  - Currently, the service is not necessary, because it does not requires ReadAction. (It just travel file system, not PsiElements) 
- `MiseTaskService` will indexes the informations to resolving the tasks
  - This caches the PsiElement walking result, which requires ReadAction.
  - Currently, only caches `task_config` directories. (need to support task_config toml files later)
