### PR TITLE
reafactor: Clean codes

### DIFF
--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/execution/MiseTomlTaskRunLineMarkerContributor.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/execution/MiseTomlTaskRunLineMarkerContributor.kt
@@ -1,43 +1,15 @@
 package com.github.l34130.mise.core.execution
 
-import com.github.l34130.mise.core.lang.psi.MiseTomlPsiPatterns
-import com.github.l34130.mise.core.lang.psi.or
 import com.github.l34130.mise.core.model.MiseTask
 import com.intellij.execution.lineMarker.RunLineMarkerContributor
-import com.intellij.icons.AllIcons
 import com.intellij.psi.PsiElement
-import org.toml.lang.psi.TomlKey
 import org.toml.lang.psi.TomlTable
-import org.toml.lang.psi.TomlTableHeader
 
 class MiseTomlTaskRunLineMarkerContributor : RunLineMarkerContributor() {
     override fun getInfo(element: PsiElement): Info? {
-        if (!(MiseTomlPsiPatterns.miseTomlStringLiteral or MiseTomlPsiPatterns.miseTomlLeafPsiElement).accepts(element)) return null
-        val tomlKey = element.parent.parent as? TomlKey ?: return null
-
-        val tomlTableHeader = tomlKey.parent as? TomlTableHeader
-        if (tomlTableHeader != null) {
-            val segments = tomlTableHeader.key?.segments ?: return null
-            if (segments.size == 2 && segments.first().name == "tasks") {
-                if (segments.first() != element.parent) { // escape self (tasks)
-                    val task = MiseTask.TomlTable.resolveOrNull(segments[1]) ?: return null
-                    return Info(AllIcons.Actions.Execute, { "" }, RunMiseTomlTaskAction(task))
-                }
-            }
+        MiseTask.TomlTable.resolveOrNull(element)?.let { task ->
+            return Info(RunMiseTomlTaskAction(task))
         }
-
-        val tomlTable = tomlKey.parent.parent as? TomlTable
-        val taskName = tomlKey.segments.singleOrNull()
-        if (tomlTable != null && taskName != null) {
-            if (tomlKey.parent != tomlTable.header) { // escape self (tasks)
-                val segments = tomlTable.header.key?.segments ?: return null
-                if (segments.size == 1 && segments.first().name == "tasks") {
-                    val task = MiseTask.TomlTable.resolveOrNull(taskName) ?: return null
-                    return Info(AllIcons.Actions.Execute, { "" }, RunMiseTomlTaskAction(task))
-                }
-            }
-        }
-
         return null
     }
 }

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/execution/MiseTomlTaskRunLineMarkerContributor.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/execution/MiseTomlTaskRunLineMarkerContributor.kt
@@ -1,25 +1,43 @@
 package com.github.l34130.mise.core.execution
 
-import com.github.l34130.mise.core.lang.psi.isSpecificTaskTableHeader
-import com.github.l34130.mise.core.lang.psi.miseTomlTask
+import com.github.l34130.mise.core.lang.psi.MiseTomlPsiPatterns
+import com.github.l34130.mise.core.lang.psi.or
+import com.github.l34130.mise.core.model.MiseTask
 import com.intellij.execution.lineMarker.RunLineMarkerContributor
 import com.intellij.icons.AllIcons
 import com.intellij.psi.PsiElement
-import org.toml.lang.psi.TomlFileType
 import org.toml.lang.psi.TomlKey
+import org.toml.lang.psi.TomlTable
 import org.toml.lang.psi.TomlTableHeader
 
 class MiseTomlTaskRunLineMarkerContributor : RunLineMarkerContributor() {
     override fun getInfo(element: PsiElement): Info? {
-        if (element.containingFile.fileType !is TomlFileType) return null
+        if (!(MiseTomlPsiPatterns.miseTomlStringLiteral or MiseTomlPsiPatterns.miseTomlLeafPsiElement).accepts(element)) return null
         val tomlKey = element.parent.parent as? TomlKey ?: return null
-        val header = tomlKey.parent as? TomlTableHeader ?: return null
-        val miseTomlTask =
-            if (header.isSpecificTaskTableHeader) {
-                header.miseTomlTask.takeIf { header.key?.segments?.getOrNull(1) == element.parent }
-            } else {
-                header.miseTomlTask
-            } ?: return null
-        return Info(AllIcons.Actions.Execute, { "" }, RunMiseTomlTaskAction(miseTomlTask))
+
+        val tomlTableHeader = tomlKey.parent as? TomlTableHeader
+        if (tomlTableHeader != null) {
+            val segments = tomlTableHeader.key?.segments ?: return null
+            if (segments.size == 2 && segments.first().name == "tasks") {
+                if (segments.first() != element.parent) { // escape self (tasks)
+                    val task = MiseTask.TomlTable.resolveOrNull(segments[1]) ?: return null
+                    return Info(AllIcons.Actions.Execute, { "" }, RunMiseTomlTaskAction(task))
+                }
+            }
+        }
+
+        val tomlTable = tomlKey.parent.parent as? TomlTable
+        val taskName = tomlKey.segments.singleOrNull()
+        if (tomlTable != null && taskName != null) {
+            if (tomlKey.parent != tomlTable.header) { // escape self (tasks)
+                val segments = tomlTable.header.key?.segments ?: return null
+                if (segments.size == 1 && segments.first().name == "tasks") {
+                    val task = MiseTask.TomlTable.resolveOrNull(taskName) ?: return null
+                    return Info(AllIcons.Actions.Execute, { "" }, RunMiseTomlTaskAction(task))
+                }
+            }
+        }
+
+        return null
     }
 }

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/execution/RunMiseTomlTaskAction.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/execution/RunMiseTomlTaskAction.kt
@@ -21,11 +21,18 @@ internal class RunMiseTomlTaskAction(
         AllIcons.Actions.Execute,
     ) {
     override fun actionPerformed(event: AnActionEvent) {
-        val dataContext =
+        var dataContext =
             SimpleDataContext.getSimpleContext(
                 Location.DATA_KEY,
                 PsiLocation((miseTask as MiseTask.TomlTable).keySegment),
                 event.dataContext,
+            )
+
+        dataContext =
+            SimpleDataContext.getSimpleContext(
+                MiseTask.DATA_KEY,
+                miseTask,
+                dataContext,
             )
 
         val context = ConfigurationContext.getFromContext(dataContext, event.place)

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/execution/RunMiseTomlTaskAction.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/execution/RunMiseTomlTaskAction.kt
@@ -1,6 +1,7 @@
 package com.github.l34130.mise.core.execution
 
 import com.github.l34130.mise.core.execution.configuration.MiseTomlTaskRunConfigurationProducer
+import com.github.l34130.mise.core.model.MiseTask
 import com.intellij.execution.Executor
 import com.intellij.execution.Location
 import com.intellij.execution.PsiLocation
@@ -11,12 +12,11 @@ import com.intellij.icons.AllIcons
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.impl.SimpleDataContext
-import org.toml.lang.psi.TomlKeySegment
 
 internal class RunMiseTomlTaskAction(
-    private val miseTomlTask: TomlKeySegment,
+    private val miseTask: MiseTask,
 ) : AnAction(
-        "Run Mise Toml Task",
+        "Run Mise Task '${miseTask.name}'",
         "Execute the Mise Toml task",
         AllIcons.Actions.Execute,
     ) {
@@ -24,7 +24,7 @@ internal class RunMiseTomlTaskAction(
         val dataContext =
             SimpleDataContext.getSimpleContext(
                 Location.DATA_KEY,
-                PsiLocation(miseTomlTask),
+                PsiLocation((miseTask as MiseTask.TomlTable).keySegment),
                 event.dataContext,
             )
 

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/execution/configuration/MiseTomlTaskRunConfigurationProducer.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/execution/configuration/MiseTomlTaskRunConfigurationProducer.kt
@@ -1,6 +1,5 @@
 package com.github.l34130.mise.core.execution.configuration
 
-import com.github.l34130.mise.core.lang.psi.taskName
 import com.github.l34130.mise.core.model.MiseTask
 import com.intellij.execution.actions.ConfigurationContext
 import com.intellij.execution.actions.LazyRunConfigurationProducer
@@ -8,8 +7,6 @@ import com.intellij.execution.configurations.ConfigurationFactory
 import com.intellij.openapi.components.PathMacroManager
 import com.intellij.openapi.util.Ref
 import com.intellij.psi.PsiElement
-import com.intellij.psi.util.parentOfType
-import org.toml.lang.psi.TomlTable
 
 internal class MiseTomlTaskRunConfigurationProducer : LazyRunConfigurationProducer<MiseTomlTaskRunConfiguration>() {
     override fun getConfigurationFactory(): ConfigurationFactory =
@@ -18,7 +15,10 @@ internal class MiseTomlTaskRunConfigurationProducer : LazyRunConfigurationProduc
     override fun isConfigurationFromContext(
         configuration: MiseTomlTaskRunConfiguration,
         context: ConfigurationContext,
-    ): Boolean = configuration.miseTaskName == findTaskName(context)
+    ): Boolean {
+        val task = context.dataContext.getData(MiseTask.DATA_KEY) ?: return false
+        return configuration.miseTaskName == task.name
+    }
 
     override fun setupConfigurationFromContext(
         configuration: MiseTomlTaskRunConfiguration,
@@ -31,15 +31,10 @@ internal class MiseTomlTaskRunConfigurationProducer : LazyRunConfigurationProduc
         val macroManager = PathMacroManager.getInstance(context.project)
 
         val virtualFile = context.location?.virtualFile
-        configuration.workingDirectory = macroManager.collapsePath(virtualFile?.parent?.path ?: context.project.basePath)
+        configuration.workingDirectory = macroManager.collapsePath(virtualFile?.parent?.path ?: context.project.basePath) // FIXME: path is not resolved correctly
 
         configuration.name = "Run ${task.name}"
 
         return true
-    }
-
-    private fun findTaskName(context: ConfigurationContext): String? {
-        val table = context.psiLocation?.parentOfType<TomlTable>() ?: return null
-        return table.taskName
     }
 }

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/execution/configuration/MiseTomlTaskRunConfigurationProducer.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/execution/configuration/MiseTomlTaskRunConfigurationProducer.kt
@@ -1,10 +1,10 @@
 package com.github.l34130.mise.core.execution.configuration
 
+import com.github.l34130.mise.core.baseDirectory
 import com.github.l34130.mise.core.model.MiseTask
 import com.intellij.execution.actions.ConfigurationContext
 import com.intellij.execution.actions.LazyRunConfigurationProducer
 import com.intellij.execution.configurations.ConfigurationFactory
-import com.intellij.openapi.components.PathMacroManager
 import com.intellij.openapi.util.Ref
 import com.intellij.psi.PsiElement
 
@@ -27,14 +27,8 @@ internal class MiseTomlTaskRunConfigurationProducer : LazyRunConfigurationProduc
     ): Boolean {
         val task = context.dataContext.getData(MiseTask.DATA_KEY) ?: return false
         configuration.miseTaskName = task.name
-
-        val macroManager = PathMacroManager.getInstance(context.project)
-
-        val virtualFile = context.location?.virtualFile
-        configuration.workingDirectory = macroManager.collapsePath(virtualFile?.parent?.path ?: context.project.basePath) // FIXME: path is not resolved correctly
-
+        configuration.workingDirectory = context.project.baseDirectory()
         configuration.name = "Run ${task.name}"
-
         return true
     }
 }

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/execution/configuration/MiseTomlTaskRunConfigurationProducer.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/execution/configuration/MiseTomlTaskRunConfigurationProducer.kt
@@ -9,7 +9,6 @@ import com.intellij.openapi.components.PathMacroManager
 import com.intellij.openapi.util.Ref
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.parentOfType
-import org.toml.lang.psi.TomlKeySegment
 import org.toml.lang.psi.TomlTable
 
 internal class MiseTomlTaskRunConfigurationProducer : LazyRunConfigurationProducer<MiseTomlTaskRunConfiguration>() {
@@ -26,9 +25,7 @@ internal class MiseTomlTaskRunConfigurationProducer : LazyRunConfigurationProduc
         context: ConfigurationContext,
         sourceElement: Ref<PsiElement>,
     ): Boolean {
-        val tomlKeySegment = context.psiLocation as? TomlKeySegment ?: return false
-
-        val task = MiseTask.TomlTable.resolveOrNull(tomlKeySegment) ?: return false
+        val task = context.dataContext.getData(MiseTask.DATA_KEY) ?: return false
         configuration.miseTaskName = task.name
 
         val macroManager = PathMacroManager.getInstance(context.project)

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/execution/configuration/MiseTomlTaskRunConfigurationProducer.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/execution/configuration/MiseTomlTaskRunConfigurationProducer.kt
@@ -1,6 +1,7 @@
 package com.github.l34130.mise.core.execution.configuration
 
 import com.github.l34130.mise.core.lang.psi.taskName
+import com.github.l34130.mise.core.model.MiseTask
 import com.intellij.execution.actions.ConfigurationContext
 import com.intellij.execution.actions.LazyRunConfigurationProducer
 import com.intellij.execution.configurations.ConfigurationFactory
@@ -8,10 +9,10 @@ import com.intellij.openapi.components.PathMacroManager
 import com.intellij.openapi.util.Ref
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.parentOfType
-import org.toml.lang.psi.TomlFile
+import org.toml.lang.psi.TomlKeySegment
 import org.toml.lang.psi.TomlTable
 
-class MiseTomlTaskRunConfigurationProducer : LazyRunConfigurationProducer<MiseTomlTaskRunConfiguration>() {
+internal class MiseTomlTaskRunConfigurationProducer : LazyRunConfigurationProducer<MiseTomlTaskRunConfiguration>() {
     override fun getConfigurationFactory(): ConfigurationFactory =
         MiseTomlTaskRunConfigurationFactory(MiseTomlTaskRunConfigurationType.getInstance())
 
@@ -25,17 +26,17 @@ class MiseTomlTaskRunConfigurationProducer : LazyRunConfigurationProducer<MiseTo
         context: ConfigurationContext,
         sourceElement: Ref<PsiElement>,
     ): Boolean {
-        if (context.psiLocation?.containingFile !is TomlFile) return false
+        val tomlKeySegment = context.psiLocation as? TomlKeySegment ?: return false
 
-        val taskName = findTaskName(context) ?: return false
-        configuration.miseTaskName = taskName
+        val task = MiseTask.TomlTable.resolveOrNull(tomlKeySegment) ?: return false
+        configuration.miseTaskName = task.name
 
         val macroManager = PathMacroManager.getInstance(context.project)
 
         val virtualFile = context.location?.virtualFile
         configuration.workingDirectory = macroManager.collapsePath(virtualFile?.parent?.path ?: context.project.basePath)
 
-        configuration.name = "Run $taskName"
+        configuration.name = "Run ${task.name}"
 
         return true
     }

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/lang/annotation/MiseAnnotator.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/lang/annotation/MiseAnnotator.kt
@@ -1,0 +1,23 @@
+package com.github.l34130.mise.core.lang.annotation
+
+import com.github.l34130.mise.core.model.MiseTask
+import com.intellij.lang.annotation.AnnotationHolder
+import com.intellij.lang.annotation.Annotator
+import com.intellij.lang.annotation.HighlightSeverity
+import com.intellij.openapi.editor.DefaultLanguageHighlighterColors
+import com.intellij.psi.PsiElement
+
+class MiseAnnotator : Annotator {
+    override fun annotate(
+        element: PsiElement,
+        holder: AnnotationHolder,
+    ) {
+        MiseTask.TomlTable.resolveOrNull(element)?.let { task ->
+            holder
+                .newSilentAnnotation(HighlightSeverity.INFORMATION)
+                .range(element)
+                .textAttributes(DefaultLanguageHighlighterColors.CLASS_NAME)
+                .create()
+        }
+    }
+}

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/lang/completion/MiseDevToolsCompletionContributor.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/lang/completion/MiseDevToolsCompletionContributor.kt
@@ -1,0 +1,3 @@
+package com.github.l34130.mise.core.lang.completion
+
+// class MiseDevToolsCompletionContributor : CompletionProvider<CompletionParameters>()

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/lang/completion/MiseTomlCompletionContributor.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/lang/completion/MiseTomlCompletionContributor.kt
@@ -13,7 +13,7 @@ class MiseTomlCompletionContributor : CompletionContributor() {
                 MiseTomlPsiPatterns.inTaskDependsString or
                 MiseTomlPsiPatterns.inTaskWaitForArray or
                 MiseTomlPsiPatterns.inTaskWaitForString,
-            MiseTomlTaskDependsCompletionProvider(),
+            MiseTomlTaskCompletionProvider(),
         )
     }
 }

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/lang/completion/MiseTomlTaskCompletionProvider.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/lang/completion/MiseTomlTaskCompletionProvider.kt
@@ -85,7 +85,7 @@ class MiseTomlTaskCompletionProvider : CompletionProvider<CompletionParameters>(
         }
         // [tasks]
         // <task-name> = { ... }
-        (element.parent.parent.parent.parent as? TomlInlineTable)?.let { tomlInlineTable ->
+        (element.parent.parent.parent as? TomlInlineTable ?: element.parent.parent.parent.parent as? TomlInlineTable)?.let { tomlInlineTable ->
             (tomlInlineTable.parent as? TomlKeyValue)?.key?.segments?.singleOrNull()?.let { currentTaskSegment = it }
         }
         if (currentTaskSegment == null) return

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/lang/completion/MiseTomlTaskCompletionProvider.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/lang/completion/MiseTomlTaskCompletionProvider.kt
@@ -79,9 +79,12 @@ class MiseTomlTaskCompletionProvider : CompletionProvider<CompletionParameters>(
         val dependsArray = (element.parent.parent as? TomlArray)
 
         var currentTaskSegment: TomlKeySegment? = null
-        (element.parent.parent.parent as? TomlTable)?.let { tomlTable ->
+        // [tasks.<task-name>]
+        (element.parent.parent.parent as? TomlTable ?: element.parent.parent.parent.parent as? TomlTable)?.let { tomlTable ->
             tomlTable.header.key?.segments?.getOrNull(1)?.let { currentTaskSegment = it }
         }
+        // [tasks]
+        // <task-name> = { ... }
         (element.parent.parent.parent.parent as? TomlInlineTable)?.let { tomlInlineTable ->
             (tomlInlineTable.parent as? TomlKeyValue)?.key?.segments?.singleOrNull()?.let { currentTaskSegment = it }
         }

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/lang/completion/MiseTomlTaskCompletionProvider.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/lang/completion/MiseTomlTaskCompletionProvider.kt
@@ -3,7 +3,6 @@ package com.github.l34130.mise.core.lang.completion
 import com.github.l34130.mise.core.MiseService
 import com.github.l34130.mise.core.collapsePath
 import com.github.l34130.mise.core.lang.psi.stringValue
-import com.github.l34130.mise.core.lang.psi.taskName
 import com.github.l34130.mise.core.model.MiseTask
 import com.intellij.codeInsight.completion.CompletionParameters
 import com.intellij.codeInsight.completion.CompletionProvider
@@ -16,24 +15,26 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.util.Iconable
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.findPsiFile
-import com.intellij.psi.util.parentOfType
 import com.intellij.testFramework.LightVirtualFile
 import com.intellij.util.ProcessingContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import org.toml.lang.psi.TomlArray
 import org.toml.lang.psi.TomlFile
+import org.toml.lang.psi.TomlInlineTable
+import org.toml.lang.psi.TomlKeySegment
+import org.toml.lang.psi.TomlKeyValue
 import org.toml.lang.psi.TomlTable
 
 /**
- * ```
+ * ```toml
  * [tasks.foo]
  * run = "..."
  * ```
  *
  * then
  *
- * ```
+ * ```toml
  * [tasks.<task-name>]
  * depends = [ "f<caret>" ]
  *             #^ Provides completion for "foo"
@@ -41,13 +42,29 @@ import org.toml.lang.psi.TomlTable
  *
  * or
  *
- * ```
+ * ```toml
  * [tasks.<task-name>]
  * depends = "f<caret>"
  *           #^ Provides completion for "foo"
  * ```
+ *
+ * or
+ *
+ * ```toml
+ * [tasks]
+ * <task-name> = { depends = [ "f<caret>" ] }
+ *                             #^ Provides completion for "foo"
+ * ```
+ * or
+ *
+ * ```toml
+ * [tasks]
+ * <task-name> = { depends = "f<caret>" }
+ *                           #^ Provides completion for "foo"
+ * ```
  */
-class MiseTomlTaskDependsCompletionProvider : CompletionProvider<CompletionParameters>() {
+class MiseTomlTaskCompletionProvider : CompletionProvider<CompletionParameters>() {
+    @Suppress("ktlint:standard:chain-method-continuation")
     override fun addCompletions(
         parameters: CompletionParameters,
         context: ProcessingContext,
@@ -55,19 +72,26 @@ class MiseTomlTaskDependsCompletionProvider : CompletionProvider<CompletionParam
     ) {
         val element = parameters.position
         val project = element.project
+
         val currentPsiFile = element.containingFile as? TomlFile ?: return // element.containingFile is in memory file
         val originalFile = (currentPsiFile.viewProvider.virtualFile as LightVirtualFile).originalFile
 
         val dependsArray = (element.parent.parent as? TomlArray)
 
-        val parentTable = element.parentOfType<TomlTable>() ?: return
-        val currentTaskName = parentTable.taskName
+        var currentTaskSegment: TomlKeySegment? = null
+        (element.parent.parent.parent as? TomlTable)?.let { tomlTable ->
+            tomlTable.header.key?.segments?.getOrNull(1)?.let { currentTaskSegment = it }
+        }
+        (element.parent.parent.parent.parent as? TomlInlineTable)?.let { tomlInlineTable ->
+            (tomlInlineTable.parent as? TomlKeyValue)?.key?.segments?.singleOrNull()?.let { currentTaskSegment = it }
+        }
+        if (currentTaskSegment == null) return
 
         runBlocking(Dispatchers.IO) {
             smartReadAction(project) {
                 for (task in project.service<MiseService>().getTasks()) {
                     if (dependsArray?.elements?.any { it.stringValue == task.name } == true) continue
-                    if (task.name == currentTaskName) continue
+                    if (task.name == currentTaskSegment.name) continue
 
                     val psiElement =
                         when (task) {

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/lang/psi/MiseTomlPsiPatterns.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/lang/psi/MiseTomlPsiPatterns.kt
@@ -22,7 +22,7 @@ import org.toml.lang.psi.ext.kind
 import org.toml.lang.psi.ext.name
 
 object MiseTomlPsiPatterns {
-    private inline fun <reified I : PsiElement> tomlPsiElement(): PsiElementPattern.Capture<I> =
+    inline fun <reified I : PsiElement> tomlPsiElement(): PsiElementPattern.Capture<I> =
         psiElement<I>().inVirtualFile(
             VirtualFilePattern().ofType(TomlFileType),
         )

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/lang/psi/MiseTomlPsiPatterns.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/lang/psi/MiseTomlPsiPatterns.kt
@@ -11,6 +11,7 @@ import com.intellij.psi.impl.source.tree.LeafPsiElement
 import com.intellij.util.ProcessingContext
 import org.toml.lang.psi.TomlArray
 import org.toml.lang.psi.TomlFileType
+import org.toml.lang.psi.TomlInlineTable
 import org.toml.lang.psi.TomlKeyValue
 import org.toml.lang.psi.TomlLiteral
 import org.toml.lang.psi.TomlTable
@@ -29,37 +30,43 @@ object MiseTomlPsiPatterns {
     val miseTomlStringLiteral = tomlPsiElement<TomlLiteral>().with("stringLiteral") { e, _ -> e.kind is TomlLiteralKind.String }
     val miseTomlLeafPsiElement = tomlPsiElement<LeafPsiElement>().with("leafPsiElement") { e, _ -> e.elementType is TomlTokenType }
 
-    val onSpecificTaskTable =
+    // [tasks.foo]
+    private val onTaskSpecificTable =
         tomlPsiElement<TomlTable>()
             .withChild(
                 psiElement<TomlTableHeader>()
-                    .with("specificTaskCondition") { header: TomlTableHeader, _ ->
-                        header.isSpecificTaskTableHeader
+                    .with("taskSpecificCondition") { header: TomlTableHeader, _ ->
+                        val headerKeySegments = header.key?.segments
+                        headerKeySegments?.size == 2 && headerKeySegments[0].name == "tasks"
                     },
             )
 
+    // [tasks]
+    private val onTaskTable =
+        tomlPsiElement<TomlTable>()
+            .with("taskCondition") { table: TomlTable, _ ->
+                val headerKeySegments = table.header.key?.segments
+                headerKeySegments?.singleOrNull()?.name == "tasks"
+            }
+
     /**
-     * ```
+     * ```toml
+     * [tasks.foo]
+     * $name = []
+     * #^
+     *
      * [tasks]
      * foo = { $name = [] }
      *         #^
      * ```
-     *
-     * ```
-     * [tasks.foo]
-     * $name = []
-     * #^
-     * ```
      */
-    private fun taskProperty(name: String) =
+    fun onTaskProperty(name: String) =
         psiElement<TomlKeyValue>()
             .with("name") { e, _ -> e.key.name == name }
-            .withParent(
-                onSpecificTaskTable,
-//                onSpecificTaskTable.andOr(
-//                    psiElement<TomlInlineTable>().withSuperParent(2, onTaskTable),
-//                ),
-            )
+            .withParent(onTaskSpecificTable) or
+            psiElement<TomlKeyValue>()
+                .with("name") { e, _ -> e.key.name == name }
+                .withParent(psiElement<TomlInlineTable>().withSuperParent(2, onTaskTable))
 
     /**
      * ```
@@ -75,12 +82,12 @@ object MiseTomlPsiPatterns {
      * ```
      */
     val onTaskDependsArray =
-        psiElement<TomlArray>().withParent(taskProperty("depends")) or
-            psiElement<TomlArray>().withParent(taskProperty("depends_post"))
+        psiElement<TomlArray>().withParent(onTaskProperty("depends")) or
+            psiElement<TomlArray>().withParent(onTaskProperty("depends_post"))
     val inTaskDependsArray = tomlPsiElement<PsiElement>().inside(onTaskDependsArray)
 
     val onTaskWaitForArray =
-        psiElement<TomlArray>().withParent(taskProperty("wait_for"))
+        psiElement<TomlArray>().withParent(onTaskProperty("wait_for"))
     val inTaskWaitForArray = tomlPsiElement<PsiElement>().inside(onTaskWaitForArray)
 
     /**
@@ -97,15 +104,15 @@ object MiseTomlPsiPatterns {
      * ```
      */
     val onTaskDependsString =
-        miseTomlStringLiteral.withParent(taskProperty("depends")) or
-            miseTomlStringLiteral.withParent(taskProperty("depends_post"))
+        miseTomlStringLiteral.withParent(onTaskProperty("depends")) or
+            miseTomlStringLiteral.withParent(onTaskProperty("depends_post"))
     val inTaskDependsString = tomlPsiElement<PsiElement>().inside(onTaskDependsString)
 
     val onTaskWaitForString =
-        miseTomlStringLiteral.withParent(taskProperty("wait_for"))
+        miseTomlStringLiteral.withParent(onTaskProperty("wait_for"))
     val inTaskWaitForString = tomlPsiElement<PsiElement>().inside(onTaskWaitForString)
 
-    val onTaskRunString = miseTomlStringLiteral.withParent(taskProperty("run"))
+    val onTaskRunString = miseTomlStringLiteral.withParent(onTaskProperty("run"))
     val inTaskRunString = tomlPsiElement<PsiElement>().inside(onTaskRunString)
 
     fun <T : Any, Self : ObjectPattern<T, Self>> ObjectPattern<T, Self>.with(

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/lang/psi/MiseTomlPsiPatterns.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/lang/psi/MiseTomlPsiPatterns.kt
@@ -7,6 +7,7 @@ import com.intellij.patterns.PlatformPatterns
 import com.intellij.patterns.PsiElementPattern
 import com.intellij.patterns.VirtualFilePattern
 import com.intellij.psi.PsiElement
+import com.intellij.psi.impl.source.tree.LeafPsiElement
 import com.intellij.util.ProcessingContext
 import org.toml.lang.psi.TomlArray
 import org.toml.lang.psi.TomlFileType
@@ -14,6 +15,7 @@ import org.toml.lang.psi.TomlKeyValue
 import org.toml.lang.psi.TomlLiteral
 import org.toml.lang.psi.TomlTable
 import org.toml.lang.psi.TomlTableHeader
+import org.toml.lang.psi.TomlTokenType
 import org.toml.lang.psi.ext.TomlLiteralKind
 import org.toml.lang.psi.ext.kind
 import org.toml.lang.psi.ext.name
@@ -24,9 +26,10 @@ object MiseTomlPsiPatterns {
             VirtualFilePattern().ofType(TomlFileType),
         )
 
-    fun miseTomlStringLiteral() = tomlPsiElement<TomlLiteral>().with("stringLiteral") { e, _ -> e.kind is TomlLiteralKind.String }
+    val miseTomlStringLiteral = tomlPsiElement<TomlLiteral>().with("stringLiteral") { e, _ -> e.kind is TomlLiteralKind.String }
+    val miseTomlLeafPsiElement = tomlPsiElement<LeafPsiElement>().with("leafPsiElement") { e, _ -> e.elementType is TomlTokenType }
 
-    private val onSpecificTaskTable =
+    val onSpecificTaskTable =
         tomlPsiElement<TomlTable>()
             .withChild(
                 psiElement<TomlTableHeader>()
@@ -94,15 +97,15 @@ object MiseTomlPsiPatterns {
      * ```
      */
     val onTaskDependsString =
-        miseTomlStringLiteral().withParent(taskProperty("depends")) or
-            miseTomlStringLiteral().withParent(taskProperty("depends_post"))
+        miseTomlStringLiteral.withParent(taskProperty("depends")) or
+            miseTomlStringLiteral.withParent(taskProperty("depends_post"))
     val inTaskDependsString = tomlPsiElement<PsiElement>().inside(onTaskDependsString)
 
     val onTaskWaitForString =
-        miseTomlStringLiteral().withParent(taskProperty("wait_for"))
+        miseTomlStringLiteral.withParent(taskProperty("wait_for"))
     val inTaskWaitForString = tomlPsiElement<PsiElement>().inside(onTaskWaitForString)
 
-    val onTaskRunString = miseTomlStringLiteral().withParent(taskProperty("run"))
+    val onTaskRunString = miseTomlStringLiteral.withParent(taskProperty("run"))
     val inTaskRunString = tomlPsiElement<PsiElement>().inside(onTaskRunString)
 
     fun <T : Any, Self : ObjectPattern<T, Self>> ObjectPattern<T, Self>.with(

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/lang/psi/MiseTomlPsiUtils.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/lang/psi/MiseTomlPsiUtils.kt
@@ -1,7 +1,6 @@
 package com.github.l34130.mise.core.lang.psi
 
 import com.github.l34130.mise.core.model.MiseTask
-import com.intellij.psi.impl.source.tree.LeafPsiElement
 import com.intellij.psi.util.childrenOfType
 import com.intellij.util.concurrency.annotations.RequiresReadLock
 import org.toml.lang.psi.TomlArray
@@ -11,7 +10,6 @@ import org.toml.lang.psi.TomlKeyValueOwner
 import org.toml.lang.psi.TomlLiteral
 import org.toml.lang.psi.TomlTable
 import org.toml.lang.psi.TomlTableHeader
-import org.toml.lang.psi.TomlTokenType
 import org.toml.lang.psi.TomlValue
 import org.toml.lang.psi.ext.TomlLiteralKind
 import org.toml.lang.psi.ext.kind
@@ -71,22 +69,6 @@ val TomlTableHeader.isSpecificTaskTableHeader: Boolean
     get() {
         val names = key?.segments.orEmpty()
         return names.getOrNull(names.size - 2)?.name == "tasks"
-    }
-
-/**
- * ```
- * [tasks]
- * foo = {  }
- * ```
- */
-@get:RequiresReadLock
-val LeafPsiElement.isInlineTaskKey: Boolean
-    get() {
-        if (this.elementType !is TomlTokenType) return false
-        val table = this.parent.parent.parent.parent as? TomlTable ?: return false
-        val header = table.header
-        val segments = header.key?.segments ?: return false
-        return segments.singleOrNull()?.textMatches("tasks") == true
     }
 
 @RequiresReadLock

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/lang/psi/MiseTomlPsiUtils.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/lang/psi/MiseTomlPsiUtils.kt
@@ -1,50 +1,55 @@
 package com.github.l34130.mise.core.lang.psi
 
 import com.github.l34130.mise.core.model.MiseTask
-import com.intellij.psi.PsiElementResolveResult
-import com.intellij.psi.ResolveResult
+import com.intellij.psi.impl.source.tree.LeafPsiElement
 import com.intellij.psi.util.childrenOfType
 import com.intellij.util.concurrency.annotations.RequiresReadLock
 import org.toml.lang.psi.TomlArray
 import org.toml.lang.psi.TomlFile
-import org.toml.lang.psi.TomlKeySegment
+import org.toml.lang.psi.TomlKeyValue
 import org.toml.lang.psi.TomlKeyValueOwner
 import org.toml.lang.psi.TomlLiteral
 import org.toml.lang.psi.TomlTable
 import org.toml.lang.psi.TomlTableHeader
+import org.toml.lang.psi.TomlTokenType
 import org.toml.lang.psi.TomlValue
 import org.toml.lang.psi.ext.TomlLiteralKind
 import org.toml.lang.psi.ext.kind
+import kotlin.collections.getOrNull
+import kotlin.collections.orEmpty
 
 @RequiresReadLock
-fun TomlFile.allTasks(): Sequence<MiseTask.TomlTable> {
-    val explicitTasks = hashSetOf<String>()
+fun TomlFile.allTasks(): Sequence<MiseTask.TomlTable> =
+    sequence {
+        val tables = childrenOfType<TomlTable>()
+        for (table in tables) {
+            val headerKeySegments = table.header.key?.segments ?: continue
 
-    return childrenOfType<TomlTable>()
-        .asSequence()
-        .flatMap { table ->
-            val header = table.header
-            when {
-                // [tasks.<task-name>]
-                header.isSpecificTaskTableHeader -> {
-                    val lastKey = header.key?.segments?.last()
-                    if (lastKey != null && lastKey.name !in explicitTasks) {
-                        sequenceOf(lastKey)
-                    } else {
-                        emptySequence()
+            when (headerKeySegments.size) {
+                1 -> {
+                    // [tasks]
+                    // foo = {  }
+                    if (headerKeySegments.first().textMatches("tasks")) {
+                        val keyValues = table.childrenOfType<TomlKeyValue>()
+                        for (keyValue in keyValues) {
+                            val key = keyValue.key
+                            if (key.segments.size == 1) {
+                                yield(MiseTask.TomlTable.resolveOrNull(key.segments.first()))
+                            }
+                        }
                     }
                 }
-                else -> emptySequence()
+                2 -> {
+                    // [tasks.foo]
+                    val (first, second) = headerKeySegments
+                    if (first.textMatches("tasks")) {
+                        yield(MiseTask.TomlTable.resolveOrNull(second))
+                    }
+                }
+                else -> continue
             }
-        }.mapNotNull { keySegment -> MiseTask.TomlTable.resolveOrNull(keySegment) }
-        .constrainOnce()
-}
-
-@RequiresReadLock
-fun TomlFile.resolveTask(taskName: String): Sequence<ResolveResult> =
-    allTasks()
-        .filter { it.name == taskName }
-        .map { PsiElementResolveResult(it.keySegment) }
+        }
+    }.filterNotNull().constrainOnce()
 
 @get:RequiresReadLock
 val TomlTable.taskName: String?
@@ -56,21 +61,32 @@ val TomlTable.taskName: String?
         return null
     }
 
-@get:RequiresReadLock
-val TomlTableHeader.miseTomlTask: TomlKeySegment?
-    get() {
-        if (isSpecificTaskTableHeader) {
-            val headerKey = key ?: return null
-            return headerKey.segments.lastOrNull()
-        }
-        return null
-    }
-
+/**
+ * ```
+ * [tasks.foo]
+ * ```
+ */
 @get:RequiresReadLock
 val TomlTableHeader.isSpecificTaskTableHeader: Boolean
     get() {
         val names = key?.segments.orEmpty()
         return names.getOrNull(names.size - 2)?.name == "tasks"
+    }
+
+/**
+ * ```
+ * [tasks]
+ * foo = {  }
+ * ```
+ */
+@get:RequiresReadLock
+val LeafPsiElement.isInlineTaskKey: Boolean
+    get() {
+        if (this.elementType !is TomlTokenType) return false
+        val table = this.parent.parent.parent.parent as? TomlTable ?: return false
+        val header = table.header
+        val segments = header.key?.segments ?: return false
+        return segments.singleOrNull()?.textMatches("tasks") == true
     }
 
 @RequiresReadLock

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/lang/resolve/MiseTomlReferenceContributor.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/lang/resolve/MiseTomlReferenceContributor.kt
@@ -9,7 +9,7 @@ class MiseTomlReferenceContributor : PsiReferenceContributor() {
     override fun registerReferenceProviders(registrar: PsiReferenceRegistrar) {
         registrar.registerReferenceProvider(
             PlatformPatterns.or(
-                MiseTomlPsiPatterns.miseTomlStringLiteral().withParent(MiseTomlPsiPatterns.onTaskDependsArray),
+                MiseTomlPsiPatterns.miseTomlStringLiteral.withParent(MiseTomlPsiPatterns.onTaskDependsArray),
                 MiseTomlPsiPatterns.onTaskDependsString,
             ),
             MiseTomlTaskDependsReferenceProvider(),

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/model/MiseTask.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/model/MiseTask.kt
@@ -7,9 +7,11 @@ import com.github.l34130.mise.core.lang.psi.or
 import com.github.l34130.mise.core.lang.psi.stringArray
 import com.github.l34130.mise.core.lang.psi.stringValue
 import com.intellij.openapi.actionSystem.DataKey
+import com.intellij.openapi.util.UserDataHolder
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiElement
+import com.intellij.testFramework.LightVirtualFile
 import org.toml.lang.psi.TomlInlineTable
 import org.toml.lang.psi.TomlKey
 import org.toml.lang.psi.TomlKeySegment
@@ -119,5 +121,12 @@ sealed interface MiseTask {
                 return null
             }
         }
+
+        private val PsiElement.originalContainingFile: UserDataHolder?
+            get() {
+                val containingFile = this.containingFile
+                return (containingFile.viewProvider.virtualFile as? LightVirtualFile)?.originalFile
+                    ?: containingFile
+            }
     }
 }

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/model/MiseTask.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/model/MiseTask.kt
@@ -64,6 +64,9 @@ sealed interface MiseTask {
         val keySegment: TomlKeySegment,
     ) : MiseTask {
         companion object {
+            /**
+             * If the given [psiElement] is a key segment(or literal) of a task table, returns the [TomlTable] instance.
+             */
             @Suppress("ktlint:standard:chain-method-continuation")
             fun resolveOrNull(psiElement: PsiElement): TomlTable? {
                 if (!(

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/model/MiseTask.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/model/MiseTask.kt
@@ -1,16 +1,28 @@
 package com.github.l34130.mise.core.model
 
+import com.github.l34130.mise.core.lang.psi.MiseTomlPsiPatterns
 import com.github.l34130.mise.core.lang.psi.getValueWithKey
+import com.github.l34130.mise.core.lang.psi.or
 import com.github.l34130.mise.core.lang.psi.stringArray
 import com.github.l34130.mise.core.lang.psi.stringValue
+import com.intellij.openapi.actionSystem.DataKey
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiElement
+import org.toml.lang.psi.TomlInlineTable
+import org.toml.lang.psi.TomlKey
 import org.toml.lang.psi.TomlKeySegment
+import org.toml.lang.psi.TomlKeyValue
+import org.toml.lang.psi.TomlTableHeader
 
 sealed interface MiseTask {
     val name: String
     val aliases: List<String>?
     val depends: List<String>?
     val description: String?
+
+    companion object {
+        val DATA_KEY = DataKey.create<MiseTask>(javaClass.simpleName)
+    }
 
     class ShellScript internal constructor(
         override val name: String,
@@ -39,15 +51,59 @@ sealed interface MiseTask {
         val keySegment: TomlKeySegment,
     ) : MiseTask {
         companion object {
-            fun resolveOrNull(keySegment: TomlKeySegment): TomlTable? {
-                val table = keySegment.parent.parent.parent as? org.toml.lang.psi.TomlTable ?: return null
-                return TomlTable(
-                    name = keySegment.name ?: return null,
-                    description = table.getValueWithKey("description")?.stringValue,
-                    depends = table.getValueWithKey("depends")?.stringArray,
-                    aliases = table.getValueWithKey("alias")?.stringArray,
-                    keySegment = keySegment,
-                )
+            @Suppress("ktlint:standard:chain-method-continuation")
+            fun resolveOrNull(psiElement: PsiElement): TomlTable? {
+                if (!(MiseTomlPsiPatterns.miseTomlStringLiteral or MiseTomlPsiPatterns.miseTomlLeafPsiElement)
+                        .accepts(psiElement)
+                ) {
+                    return null
+                }
+
+                val tomlKey = psiElement.parent.parent as? TomlKey ?: return null
+
+                // CASE: [tasks.<TASK_NAME>]
+                (tomlKey.parent as? TomlTableHeader)?.let { tomlTableHeader ->
+                    val keySegments = tomlTableHeader.key?.segments ?: return null
+                    if (keySegments.size != 2) return null
+                    if (keySegments[0].name != "tasks") return null
+                    if (keySegments[0] == psiElement.parent) return null // escape self (tasks)
+
+                    val table = tomlTableHeader.parent as? org.toml.lang.psi.TomlTable ?: return null
+                    val keySegment = keySegments[1]
+                    return TomlTable(
+                        name = keySegment.name ?: return null,
+                        description = table.getValueWithKey("description")?.stringValue,
+                        depends = table.getValueWithKey("depends")?.stringArray,
+                        aliases = table.getValueWithKey("alias")?.stringArray,
+                        keySegment = keySegment,
+                    )
+                }
+
+                // CASE: [tasks]
+                //       <TASK_NAME> = {}
+                (tomlKey.parent.parent as? org.toml.lang.psi.TomlTable)?.let { tomlTable ->
+                    val tomlTableHeader = tomlTable.header
+                    if (tomlTableHeader == tomlKey.parent) return null // escape self (tasks)
+                    if (tomlTableHeader.key
+                            ?.segments
+                            ?.singleOrNull()
+                            ?.textMatches("tasks") != true
+                    ) {
+                        return null
+                    }
+
+                    val keySegment = tomlKey.segments.singleOrNull() ?: return null
+                    val table = (tomlKey.parent as? TomlKeyValue)?.value as? TomlInlineTable ?: return null
+                    return TomlTable(
+                        name = keySegment.name ?: return null,
+                        description = table.getValueWithKey("description")?.stringValue,
+                        depends = table.getValueWithKey("depends")?.stringArray,
+                        aliases = table.getValueWithKey("alias")?.stringArray,
+                        keySegment = keySegment,
+                    )
+                }
+
+                return null
             }
         }
     }

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/model/MiseTask.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/model/MiseTask.kt
@@ -66,13 +66,21 @@ sealed interface MiseTask {
         companion object {
             @Suppress("ktlint:standard:chain-method-continuation")
             fun resolveOrNull(psiElement: PsiElement): TomlTable? {
-                if (!(MiseTomlPsiPatterns.miseTomlStringLiteral or MiseTomlPsiPatterns.miseTomlLeafPsiElement)
-                        .accepts(psiElement)
+                if (!(
+                        MiseTomlPsiPatterns.miseTomlStringLiteral or
+                            MiseTomlPsiPatterns.miseTomlLeafPsiElement or
+                            MiseTomlPsiPatterns.tomlPsiElement<TomlKeySegment>()
+                    ).accepts(psiElement)
                 ) {
                     return null
                 }
 
-                val tomlKey = psiElement.parent.parent as? TomlKey ?: return null
+                val tomlKey =
+                    if (psiElement is TomlKeySegment) {
+                        psiElement.parent as? TomlKey
+                    } else {
+                        psiElement.parent.parent as? TomlKey
+                    } ?: return null
 
                 // CASE: [tasks.<TASK_NAME>]
                 (tomlKey.parent as? TomlTableHeader)?.let { tomlTableHeader ->

--- a/modules/core/src/test/kotlin/com/github/l34130/mise/core/lang/completion/MiseTomlTaskDependsCompletionProviderTest.kt
+++ b/modules/core/src/test/kotlin/com/github/l34130/mise/core/lang/completion/MiseTomlTaskDependsCompletionProviderTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("ktlint")
+
 package com.github.l34130.mise.core.lang.completion
 
 internal class MiseTomlTaskDependsCompletionProviderTest : MiseTomlCompletionTestBase() {
@@ -24,4 +26,71 @@ internal class MiseTomlTaskDependsCompletionProviderTest : MiseTomlCompletionTes
         [tasks.bar]
         depends_post = ["foo<caret>"]
     """)
+
+    fun `test completion inTaskWaitForArray`() = testSingleCompletion("""
+        [tasks.foo]
+        
+        [tasks.bar]
+        wait_for = ["<caret>"]
+    """, """
+        [tasks.foo]
+        
+        [tasks.bar]
+        wait_for = ["foo<caret>"]
+    """)
+
+    fun `test completion inTaskDependsArray with items`() = testSingleCompletion("""
+        [tasks.foo]
+        
+        [tasks.bar]
+        depends = ["another", "<caret>"]
+    """, """
+        [tasks.foo]
+        
+        [tasks.bar]
+        depends = ["another", "foo<caret>"]
+    """)
+
+    fun `test completion inTaskDependsString`() = testSingleCompletion("""
+        [tasks.foo]
+        
+        [tasks.bar]
+        depends = "<caret>"
+    """, """
+        [tasks.foo]
+        
+        [tasks.bar]
+        depends = "foo<caret>"
+    """)
+
+    fun `test completion inTaskDependsArray with tasks table`() = testSingleCompletion("""
+        [tasks]
+        foo = {}
+        bar = { depends = ["<caret>"] }
+    """, """
+        [tasks]
+        foo = {}
+        bar = { depends = ["foo<caret>"] }
+    """)
+
+    fun `test completion inTaskDependsArray with items with tasks table`() = testSingleCompletion("""
+        [tasks]
+        foo = {}
+        bar = { depends = ["another", "<caret>"] }
+    """, """
+        [tasks]
+        foo = {}
+        bar = { depends = ["another", "foo<caret>"] }
+    """)
+
+    fun `test completion inTaskDependsString with tasks table`() = testSingleCompletion("""
+        [tasks]
+        foo = {}
+        bar = { depends = "<caret>" }
+    """, """
+        [tasks]
+        foo = {}
+        bar = { depends = "foo<caret>" }
+    """)
+
 }

--- a/modules/core/src/test/kotlin/com/github/l34130/mise/core/lang/psi/MiseTomlPsiPatternsTest.kt
+++ b/modules/core/src/test/kotlin/com/github/l34130/mise/core/lang/psi/MiseTomlPsiPatternsTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("ktlint")
+
 package com.github.l34130.mise.core.lang.psi
 
 import com.github.l34130.mise.core.FileTestBase

--- a/modules/core/src/test/kotlin/com/github/l34130/mise/core/lang/psi/MiseTomlPsiPatternsTest.kt
+++ b/modules/core/src/test/kotlin/com/github/l34130/mise/core/lang/psi/MiseTomlPsiPatternsTest.kt
@@ -11,6 +11,18 @@ import com.jetbrains.rd.util.assert
 import org.intellij.lang.annotations.Language
 
 class MiseTomlPsiPatternsTest : FileTestBase() {
+    fun `test onTaskProperty(name) on task specific table`() = testPattern(MiseTomlPsiPatterns.onTaskProperty("name"), """
+        [tasks.foo]
+        name = []
+        #^
+    """)
+
+    fun `test onTaskProperty(name) on task table`() = testPattern(MiseTomlPsiPatterns.onTaskProperty("name"), """
+        [tasks]
+        foo = { name = [] }
+                #^
+    """)
+
     fun `test inTaskDependsArray`() = testPattern(inTaskDependsArray, """
         [tasks.foo]
         depends = ["bar", ""]

--- a/modules/core/src/test/kotlin/com/github/l34130/mise/core/lang/psi/MiseTomlPsiUtilsTest.kt
+++ b/modules/core/src/test/kotlin/com/github/l34130/mise/core/lang/psi/MiseTomlPsiUtilsTest.kt
@@ -1,0 +1,54 @@
+@file:Suppress("ktlint")
+
+package com.github.l34130.mise.core.lang.psi
+
+import com.github.l34130.mise.core.FileTestBase
+import com.intellij.psi.impl.source.tree.LeafPsiElement
+import org.intellij.lang.annotations.Language
+import org.toml.lang.psi.TomlFile
+import org.toml.lang.psi.TomlTableHeader
+
+class MiseTomlPsiUtilsTest : FileTestBase() {
+    fun `test TomlFile_allTasks`() {
+        val file = InlineTomlFile(
+            """
+            [tasks]
+            foo = {  }
+            bar = {  }
+            
+            [tasks.baz]
+            """.trimIndent(),
+        )
+        val tasks = file.allTasks().toList()
+        assert(tasks.size == 3)
+        assert(tasks[0].name == "foo")
+        assert(tasks[1].name == "bar")
+        assert(tasks[2].name == "baz")
+    }
+
+    fun `test TomlTableHeader_isSpecificTaskTableHeader`() {
+        InlineTomlFile(
+            """
+            [tasks.foo]
+                    #^
+            """.trimIndent(),
+        )
+        val element = findElementInEditor<TomlTableHeader>()
+        assert(element.isSpecificTaskTableHeader)
+    }
+
+    fun `test TomlTableHeader_isInlineTaskKey`() {
+        InlineTomlFile(
+            """
+            [tasks]
+            foo = {  }
+             #^
+            """.trimIndent(),
+        )
+        val element = findElementInEditor<LeafPsiElement>()
+        assert(element.isInlineTaskKey)
+    }
+
+    private fun InlineTomlFile(@Language("TOML") code: String, fileName: String = "mise.toml"): TomlFile =
+        InlineFile(code, fileName) as TomlFile
+}

--- a/modules/core/src/test/kotlin/com/github/l34130/mise/core/lang/psi/MiseTomlPsiUtilsTest.kt
+++ b/modules/core/src/test/kotlin/com/github/l34130/mise/core/lang/psi/MiseTomlPsiUtilsTest.kt
@@ -3,7 +3,6 @@
 package com.github.l34130.mise.core.lang.psi
 
 import com.github.l34130.mise.core.FileTestBase
-import com.intellij.psi.impl.source.tree.LeafPsiElement
 import org.intellij.lang.annotations.Language
 import org.toml.lang.psi.TomlFile
 import org.toml.lang.psi.TomlTableHeader
@@ -35,18 +34,6 @@ class MiseTomlPsiUtilsTest : FileTestBase() {
         )
         val element = findElementInEditor<TomlTableHeader>()
         assert(element.isSpecificTaskTableHeader)
-    }
-
-    fun `test TomlTableHeader_isInlineTaskKey`() {
-        InlineTomlFile(
-            """
-            [tasks]
-            foo = {  }
-             #^
-            """.trimIndent(),
-        )
-        val element = findElementInEditor<LeafPsiElement>()
-        assert(element.isInlineTaskKey)
     }
 
     private fun InlineTomlFile(@Language("TOML") code: String, fileName: String = "mise.toml"): TomlFile =

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -20,6 +20,9 @@
         <lang.documentationProvider
                 order="first" language="TOML"
                 implementationClass="com.github.l34130.mise.core.lang.resolve.MiseTaskDocumentationProvider"/>
+        <annotator
+                order="first" language="TOML"
+                implementationClass="com.github.l34130.mise.core.lang.annotation.MiseAnnotator"/>
 
         <completion.contributor
                 order="first" language="Shell Script"


### PR DESCRIPTION
- there are many scattered codes about Psi handling.
  - Centralize to `MiseTask.TomlTable.resolveOrNull()`
- Support MiseAnnotator to highlight the tasks
- Support InlineTable formatted task table.
- ```toml
  [tasks]
  foo = { ... }
  #^ This is now supported
  ```