### PR TITLE
fix: RunLineMarkerContributor is contributing on non-leaf nodes

### DIFF
--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/execution/MiseTomlTaskRunLineMarkerContributor.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/execution/MiseTomlTaskRunLineMarkerContributor.kt
@@ -3,10 +3,12 @@ package com.github.l34130.mise.core.execution
 import com.github.l34130.mise.core.model.MiseTask
 import com.intellij.execution.lineMarker.RunLineMarkerContributor
 import com.intellij.psi.PsiElement
+import com.intellij.psi.impl.source.tree.LeafPsiElement
 import org.toml.lang.psi.TomlTable
 
 class MiseTomlTaskRunLineMarkerContributor : RunLineMarkerContributor() {
     override fun getInfo(element: PsiElement): Info? {
+        if (element !is LeafPsiElement) return null
         MiseTask.TomlTable.resolveOrNull(element)?.let { task ->
             return Info(RunMiseTomlTaskAction(task))
         }


### PR DESCRIPTION
## Description

- Fix `MiseTomlTaskRunLineMarkerContributor` is contribution on non-leaf nodes
- It causes performance issues and Marker duplication.