### PR TITLE
feat: Add support for `Go to Declaration` on ToolWindow

### DIFF
--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/execution/RunMiseTomlTaskAction.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/execution/RunMiseTomlTaskAction.kt
@@ -9,6 +9,7 @@ import com.intellij.execution.RunManagerEx
 import com.intellij.execution.actions.ConfigurationContext
 import com.intellij.execution.runners.ExecutionUtil
 import com.intellij.icons.AllIcons
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.impl.SimpleDataContext
@@ -44,4 +45,6 @@ internal class RunMiseTomlTaskAction(
         runManager.setTemporaryConfiguration(configuration)
         ExecutionUtil.runConfiguration(configuration, Executor.EXECUTOR_EXTENSION_NAME.extensionList.first())
     }
+
+    override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
 }

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/model/MiseTask.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/model/MiseTask.kt
@@ -6,16 +6,12 @@ import com.github.l34130.mise.core.lang.psi.getValueWithKey
 import com.github.l34130.mise.core.lang.psi.or
 import com.github.l34130.mise.core.lang.psi.stringArray
 import com.github.l34130.mise.core.lang.psi.stringValue
-import com.intellij.lang.documentation.DocumentationMarkup
 import com.intellij.openapi.actionSystem.DataKey
-import com.intellij.openapi.project.currentOrDefaultProject
 import com.intellij.openapi.util.UserDataHolder
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiElement
-import com.intellij.sh.psi.ShFile
 import com.intellij.testFramework.LightVirtualFile
-import com.intellij.util.containers.nullize
 import org.toml.lang.psi.TomlInlineTable
 import org.toml.lang.psi.TomlKey
 import org.toml.lang.psi.TomlKeySegment
@@ -151,42 +147,5 @@ sealed interface MiseTask {
                 return (containingFile.viewProvider.virtualFile as? LightVirtualFile)?.originalFile
                     ?: containingFile
             }
-    }
-}
-
-fun MiseTask.documentationString(): String {
-    val task = this
-
-    fun StringBuilder.appendKeyValueSection(
-        key: String,
-        value: String?,
-    ) {
-        append(DocumentationMarkup.SECTION_HEADER_START)
-        append(key)
-        append(DocumentationMarkup.SECTION_SEPARATOR)
-        append("<p>")
-        append(value ?: DocumentationMarkup.GRAYED_ELEMENT.addText("None"))
-        append(DocumentationMarkup.SECTION_END)
-    }
-
-    return buildString {
-        append(DocumentationMarkup.DEFINITION_START)
-        append(task.name)
-        append(DocumentationMarkup.DEFINITION_END)
-        append(DocumentationMarkup.CONTENT_START)
-        append(task.description ?: DocumentationMarkup.GRAYED_ELEMENT.addText("No description provided."))
-        append(DocumentationMarkup.CONTENT_END)
-        append(DocumentationMarkup.SECTIONS_START)
-        appendKeyValueSection("Alias:", task.aliases.nullize()?.joinToString(", "))
-        appendKeyValueSection("Depends:", task.depends.nullize()?.joinToString(", "))
-        appendKeyValueSection(
-            "File:",
-            when (task) {
-                is MiseTask.ShellScript -> collapsePath(task.file as ShFile, task.file.project)
-                is MiseTask.TomlTable -> collapsePath(task.keySegment.containingFile, task.keySegment.project)
-                is MiseTask.Unknown -> task.source?.let { collapsePath(it, currentOrDefaultProject(null)) } ?: "unknown"
-            },
-        )
-        append(DocumentationMarkup.SECTIONS_END)
     }
 }

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/toolwindow/ActionOnRightClick.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/toolwindow/ActionOnRightClick.kt
@@ -1,0 +1,7 @@
+package com.github.l34130.mise.core.toolwindow
+
+import com.intellij.openapi.actionSystem.AnAction
+
+interface ActionOnRightClick {
+    fun actions(): List<AnAction>
+}

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/toolwindow/MiseTreeToolWindow.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/toolwindow/MiseTreeToolWindow.kt
@@ -9,6 +9,7 @@ import com.intellij.ide.util.treeView.NodeRenderer
 import com.intellij.ide.util.treeView.TreeState
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.actionSystem.ActionPlaces
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.DataProvider
@@ -121,22 +122,17 @@ class MiseTreeToolWindow(
                         val node = getSelectedNodesSameType<AbstractTreeNode<*>>()?.get(0) ?: return
                         val actionManager = ActionManager.getInstance()
                         val totalActions = mutableListOf<AnAction>()
-//                        if (node is ActionGroupOnRightClick) {
-//                            val actionGroupName = node.actionGroupName()
-//
-//                            (actionGroupName.let { groupName -> actionManager.getAction(groupName) } as? ActionGroup)?.let { group ->
-//                                val context =
-//                                    comp?.let { DataManager.getInstance().getDataContext(it, x, y) } ?: return@let
-//                                val event = AnActionEvent.createFromDataContext(actionPlace, null, context)
-//                                totalActions.addAll(group.getChildren(event))
-//                            }
-//                        }
+                        val actionPlace = ActionPlaces.TOOLWINDOW_CONTENT
+                        if (node is ActionOnRightClick) {
+                            val actions = node.actions()
+                            totalActions.addAll(actions)
+                        }
 
                         val actionGroup = DefaultActionGroup(totalActions)
                         if (actionGroup.childrenCount > 0) {
-                            // val popupMenu = actionManager.createActionPopupMenu(actionPlace, actionGroup)
-//                            popupMenu.setTargetComponent(this@AbstractExplorerTreeToolWindow)
-//                            popupMenu.component.show(comp, x, y)
+                            val popupMenu = actionManager.createActionPopupMenu(actionPlace, actionGroup)
+                            popupMenu.setTargetComponent(this@MiseTreeToolWindow)
+                            popupMenu.component.show(comp, x, y)
                         }
                     }
                 }

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/toolwindow/nodes/MiseTaskNode.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/toolwindow/nodes/MiseTaskNode.kt
@@ -2,14 +2,18 @@ package com.github.l34130.mise.core.toolwindow.nodes
 
 import com.github.l34130.mise.core.execution.RunMiseTomlTaskAction
 import com.github.l34130.mise.core.model.MiseTask
+import com.github.l34130.mise.core.toolwindow.ActionOnRightClick
 import com.github.l34130.mise.core.toolwindow.DoubleClickable
 import com.intellij.icons.AllIcons
 import com.intellij.ide.DataManager
 import com.intellij.ide.projectView.PresentationData
 import com.intellij.openapi.actionSystem.ActionPlaces
+import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.application.readAction
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.findPsiFile
+import com.intellij.util.OpenSourceUtil
 import kotlinx.coroutines.runBlocking
 import java.awt.event.MouseEvent
 
@@ -32,7 +36,8 @@ class MiseTaskNode(
         taskInfo,
         AllIcons.Debugger.Console,
     ),
-    DoubleClickable {
+    DoubleClickable,
+    ActionOnRightClick {
     override fun displayName(): String = taskInfo.name
 
     override fun createPresentation(): PresentationData =
@@ -56,4 +61,26 @@ class MiseTaskNode(
 
         action.actionPerformed(actionEvent)
     }
+
+    override fun actions(): List<AnAction> =
+        listOfNotNull(
+            RunMiseTomlTaskAction(taskInfo),
+            when (taskInfo) {
+                is MiseTask.ShellScript -> {
+                    object : AnAction("Go to Declaration", "Go to Declaration", AllIcons.General.Locate) {
+                        override fun actionPerformed(e: AnActionEvent) {
+                            OpenSourceUtil.navigateToSource(false, true, taskInfo.file.findPsiFile(project))
+                        }
+                    }
+                }
+                is MiseTask.TomlTable -> {
+                    object : AnAction("Go to Declaration", "Go to Declaration", AllIcons.General.Locate) {
+                        override fun actionPerformed(e: AnActionEvent) {
+                            OpenSourceUtil.navigateToSource(false, true, taskInfo.keySegment)
+                        }
+                    }
+                }
+                is MiseTask.Unknown -> null
+            },
+        )
 }


### PR DESCRIPTION
Add support for `Go to Declaration` on MiseTreeToolWindow

![image](https://github.com/user-attachments/assets/90e8a8e3-a2f6-44e1-a696-f97875159da6)
