### PR TITLE
feat(clion): Add environment variable injection for C/C++

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -9,6 +9,7 @@
           <set>
             <option value="$PROJECT_DIR$" />
             <option value="$PROJECT_DIR$/modules/core" />
+            <option value="$PROJECT_DIR$/modules/products/clion" />
             <option value="$PROJECT_DIR$/modules/products/diagram" />
             <option value="$PROJECT_DIR$/modules/products/goland" />
             <option value="$PROJECT_DIR$/modules/products/gradle" />

--- a/README.md
+++ b/README.md
@@ -37,7 +37,11 @@
 - **Node.js**
   - Node.js
   - npm
-  - Deno 
+  - Deno
+- **C / C++** (only support for application level settings)
+  - C/C++ File
+  - CMake Application
+  - Makefile target
 - **C#**
 - _Submit issue if you need others_
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
     intellijPlatform {
         create(IntelliJPlatformType.IntellijIdeaCommunity, providers.gradleProperty("platformVersion"), false)
 
+        pluginModule(implementation(project(":mise-products-clion")))
         pluginModule(implementation(project(":mise-products-diagram")))
         pluginModule(implementation(project(":mise-products-goland")))
         pluginModule(implementation(project(":mise-products-gradle")))
@@ -160,6 +161,7 @@ allprojects {
         detekt("io.gitlab.arturbosch.detekt:detekt-cli:${rootProject.libs.versions.detekt.get()}")
         detekt("io.gitlab.arturbosch.detekt:detekt-formatting:${rootProject.libs.versions.detekt.get()}")
         detekt(project(":mise-core"))
+        detekt(project(":mise-products-clion"))
         detekt(project(":mise-products-diagram"))
         detekt(project(":mise-products-goland"))
         detekt(project(":mise-products-gradle"))
@@ -209,6 +211,7 @@ val runIdeForUnitTests by intellijPlatformTesting.runIde.registering {
 
 val runIdePlatformTypes =
     listOf(
+        IntelliJPlatformType.CLion,
         IntelliJPlatformType.GoLand,
         IntelliJPlatformType.IntellijIdeaCommunity,
         IntelliJPlatformType.IntellijIdeaUltimate,

--- a/modules/products/clion/build.gradle.kts
+++ b/modules/products/clion/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
     intellijPlatform {
         create(IntelliJPlatformType.CLion, properties("platformVersion"))
 
-        bundledPlugins("com.intellij.clion", "com.intellij.cidr.base", "com.intellij.cidr.lang")
+        bundledPlugins("com.intellij.clion", "com.intellij.cidr.base", "com.intellij.nativeDebug")
 
         jetbrainsRuntime()
 

--- a/modules/products/clion/build.gradle.kts
+++ b/modules/products/clion/build.gradle.kts
@@ -1,0 +1,26 @@
+import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
+import org.jetbrains.intellij.platform.gradle.TestFrameworkType
+
+fun properties(key: String) = project.findProperty(key).toString()
+
+plugins {
+    id("org.jetbrains.intellij.platform.module")
+    alias(libs.plugins.kotlin) // Kotlin support
+}
+
+dependencies {
+    implementation(project(":mise-core"))
+    testImplementation(libs.junit)
+
+    // Configure Gradle IntelliJ Plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
+    intellijPlatform {
+        create(IntelliJPlatformType.CLion, properties("platformVersion"))
+
+        bundledPlugins("com.intellij.clion", "com.intellij.cidr.base", "com.intellij.cidr.lang")
+
+        jetbrainsRuntime()
+
+        testFramework(TestFrameworkType.Platform)
+        testImplementation("org.opentest4j:opentest4j:1.3.0")
+    }
+}

--- a/modules/products/clion/src/main/kotlin/com/github/l34130/mise/clion/run/MiseCidrRunConfigurationExtension.kt
+++ b/modules/products/clion/src/main/kotlin/com/github/l34130/mise/clion/run/MiseCidrRunConfigurationExtension.kt
@@ -1,20 +1,58 @@
 package com.github.l34130.mise.clion.run
 
+import com.github.l34130.mise.core.MiseHelper
+import com.github.l34130.mise.core.run.MiseRunConfigurationSettingsEditor
+import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.configurations.RunnerSettings
+import com.intellij.openapi.options.SettingsEditor
+import com.intellij.openapi.util.NlsContexts
 import com.jetbrains.cidr.execution.CidrRunConfigurationExtensionBase
-import com.jetbrains.cidr.lang.workspace.OCRunConfiguration
+import com.jetbrains.cidr.execution.ConfigurationExtensionContext
 import com.jetbrains.cidr.lang.toolchains.CidrToolEnvironment
-import org.jetbrains.intellij.build.impl.Git
+import com.jetbrains.cidr.lang.workspace.OCRunConfiguration
+import org.jdom.Element
 
 class MiseCidrRunConfigurationExtension : CidrRunConfigurationExtensionBase() {
     override fun isEnabledFor(
         runConfiguration: OCRunConfiguration<*, *>,
         toolEnvironment: CidrToolEnvironment,
-        runnerSettings: RunnerSettings?
-    ): Boolean {
-        Git
-        return true
-    }
+        runnerSettings: RunnerSettings?,
+    ): Boolean = true
 
     override fun isApplicableFor(runConfiguration: OCRunConfiguration<*, *>): Boolean = true
+
+    override fun getSerializationId(): String = MiseRunConfigurationSettingsEditor.SERIALIZATION_ID
+
+    override fun getEditorTitle(): @NlsContexts.TabTitle String? = MiseRunConfigurationSettingsEditor.EDITOR_TITLE
+
+    // NOTE: C/C++, CMake, Makefile doesn't allow extending the run configuration editor
+    override fun <P : OCRunConfiguration<*, *>> createEditor(configuration: P): SettingsEditor<P> =
+        MiseRunConfigurationSettingsEditor(configuration.project)
+
+    override fun readExternal(
+        runConfiguration: OCRunConfiguration<*, *>,
+        element: Element,
+    ) {
+        MiseRunConfigurationSettingsEditor.readExternal(runConfiguration, element)
+    }
+
+    override fun writeExternal(
+        runConfiguration: OCRunConfiguration<*, *>,
+        element: Element,
+    ) {
+        MiseRunConfigurationSettingsEditor.writeExternal(runConfiguration, element)
+    }
+
+    override fun patchCommandLine(
+        configuration: OCRunConfiguration<*, *>,
+        runnerSettings: RunnerSettings?,
+        environment: CidrToolEnvironment,
+        cmdLine: GeneralCommandLine,
+        runnerId: String,
+        context: ConfigurationExtensionContext,
+    ) {
+        MiseHelper
+            .getMiseEnvVarsOrNotify(configuration, configuration::getWorkingDirectory)
+            .forEach { (k, v) -> cmdLine.withEnvironment(k, v) }
+    }
 }

--- a/modules/products/clion/src/main/kotlin/com/github/l34130/mise/clion/run/MiseCidrRunConfigurationExtension.kt
+++ b/modules/products/clion/src/main/kotlin/com/github/l34130/mise/clion/run/MiseCidrRunConfigurationExtension.kt
@@ -1,0 +1,20 @@
+package com.github.l34130.mise.clion.run
+
+import com.intellij.execution.configurations.RunnerSettings
+import com.jetbrains.cidr.execution.CidrRunConfigurationExtensionBase
+import com.jetbrains.cidr.lang.workspace.OCRunConfiguration
+import com.jetbrains.cidr.lang.toolchains.CidrToolEnvironment
+import org.jetbrains.intellij.build.impl.Git
+
+class MiseCidrRunConfigurationExtension : CidrRunConfigurationExtensionBase() {
+    override fun isEnabledFor(
+        runConfiguration: OCRunConfiguration<*, *>,
+        toolEnvironment: CidrToolEnvironment,
+        runnerSettings: RunnerSettings?
+    ): Boolean {
+        Git
+        return true
+    }
+
+    override fun isApplicableFor(runConfiguration: OCRunConfiguration<*, *>): Boolean = true
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,6 +18,7 @@ dependencyResolutionManagement {
 
 include(
     "modules/core",
+    "modules/products/clion",
     "modules/products/diagram",
     "modules/products/goland",
     "modules/products/gradle",

--- a/src/main/resources/META-INF/mise-clion.xml
+++ b/src/main/resources/META-INF/mise-clion.xml
@@ -1,7 +1,6 @@
 <idea-plugin require-restart="false">
     <depends>com.intellij.clion</depends>
     <depends>com.intellij.cidr.base</depends>
-    <depends>com.intellij.cidr.lang</depends>
 
     <extensions defaultExtensionNs="cidr">
         <runConfigurationExtension implementation="com.github.l34130.mise.clion.run.MiseCidrRunConfigurationExtension"/>

--- a/src/main/resources/META-INF/mise-clion.xml
+++ b/src/main/resources/META-INF/mise-clion.xml
@@ -1,0 +1,9 @@
+<idea-plugin require-restart="false">
+    <depends>com.intellij.clion</depends>
+    <depends>com.intellij.cidr.base</depends>
+    <depends>com.intellij.cidr.lang</depends>
+
+    <extensions defaultExtensionNs="cidr">
+        <runConfigurationExtension implementation="com.github.l34130.mise.clion.run.MiseCidrRunConfigurationExtension"/>
+    </extensions>
+</idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -67,6 +67,7 @@
         </group>
     </actions>
 
+    <depends optional="true" config-file="mise-clion.xml">com.intellij.clion</depends>
     <depends optional="true" config-file="mise-diagram.xml">com.intellij.diagram</depends>
     <depends optional="true" config-file="mise-goland.xml">org.jetbrains.plugins.go</depends>
     <depends optional="true" config-file="mise-gradle.xml">com.intellij.gradle</depends>


### PR DESCRIPTION
- Closes: #165
- There is no way to inject mise editor to existing run configurations(CMake, C/C++, Makefile).
- So just support for application level settings.