### PR TITLE
fix: Indicate progress for getting mise envvars

### DIFF
--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/MiseHelper.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/MiseHelper.kt
@@ -7,10 +7,8 @@ import com.github.l34130.mise.core.run.MiseRunConfigurationSettingsEditor
 import com.github.l34130.mise.core.setting.MiseProjectSettings
 import com.intellij.execution.configurations.RunConfigurationBase
 import com.intellij.openapi.components.service
-import com.intellij.platform.ide.progress.TaskCancellation
-import com.intellij.platform.ide.progress.withBackgroundProgress
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.runBlocking
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.util.ThrowableComputable
 import java.util.function.Supplier
 
 object MiseHelper {
@@ -33,8 +31,8 @@ object MiseHelper {
                 else -> return emptyMap()
             }
 
-        return runBlocking(Dispatchers.IO) {
-            withBackgroundProgress(configuration.project, "Getting Mise envvars", TaskCancellation.nonCancellable()) {
+        return ProgressManager.getInstance().runProcessWithProgressSynchronously(
+            ThrowableComputable {
                 MiseCommandLineHelper
                     .getEnvVars(workDir, configEnvironment)
                     .fold(
@@ -46,7 +44,10 @@ object MiseHelper {
                             mapOf()
                         },
                     )
-            }
-        }
+            },
+            "Loading Mise Environment Variables",
+            true,
+            configuration.project,
+        )
     }
 }

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/command/MiseCommandLine.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/command/MiseCommandLine.kt
@@ -16,11 +16,13 @@ internal class MiseCommandLine(
 ) {
     inline fun <reified T> runCommandLine(vararg params: String): Result<T> = runCommandLine(params.toList())
 
+    @RequiresBackgroundThread
     inline fun <reified T> runCommandLine(params: List<String>): Result<T> {
         val typeReference = object : TypeReference<T>() {}
         return runCommandLine(params, typeReference)
     }
 
+    @RequiresBackgroundThread
     fun <T> runCommandLine(
         params: List<String>,
         typeReference: TypeReference<T>,
@@ -47,6 +49,7 @@ internal class MiseCommandLine(
         }
     }
 
+    @RequiresBackgroundThread
     private fun <T> runCommandLine(
         commandLineArgs: List<String>,
         transform: (String) -> T,

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/command/MiseCommandLine.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/command/MiseCommandLine.kt
@@ -32,7 +32,7 @@ internal class MiseCommandLine(
         val executablePath = application.service<MiseApplicationSettings>().state.executablePath
         val commandLineArgs = executablePath.split(' ').toMutableList()
 
-        if (configEnvironment != null) {
+        if (!configEnvironment.isNullOrBlank()) {
             if (miseVersion >= MiseVersion(2024, 12, 2)) {
                 commandLineArgs.add("--env")
                 commandLineArgs.add(configEnvironment)

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/command/MiseCommandLine.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/command/MiseCommandLine.kt
@@ -58,7 +58,7 @@ internal class MiseCommandLine(
         val processOutput =
             try {
                 logger.debug("Running command: $commandLineArgs")
-                ExecUtil.execAndGetOutput(generalCommandLine, 5000)
+                ExecUtil.execAndGetOutput(generalCommandLine, 3000)
             } catch (e: ExecutionException) {
                 logger.info("Failed to execute command. (command=$generalCommandLine)", e)
                 return Result.failure(


### PR DESCRIPTION
- There is some cases that mise needs network. But when the network is unavailable, IDE just hangs for 5 seconds without any notification.
- The UX is terrible, we need to make the task as background, but we cannot because of the interface is blocking.
- So we just uses Progress Indicator to notify to the user that the Mise process is running now.
- resolves: #250 