### PR TITLE
fix: Calling invokeAndWait from read-action leads to possible deadlock

### DIFF
--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/MiseHelper.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/MiseHelper.kt
@@ -7,6 +7,11 @@ import com.github.l34130.mise.core.run.MiseRunConfigurationSettingsEditor
 import com.github.l34130.mise.core.setting.MiseProjectSettings
 import com.intellij.execution.configurations.RunConfigurationBase
 import com.intellij.openapi.components.service
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.diagnostic.debug
+import com.intellij.openapi.progress.ProcessCanceledException
+import com.intellij.platform.ide.progress.runWithModalProgressBlocking
+import com.intellij.util.application
 import java.util.function.Supplier
 
 object MiseHelper {
@@ -29,8 +34,28 @@ object MiseHelper {
                 else -> return emptyMap()
             }
 
-        return MiseCommandLineHelper
-            .getEnvVars(workDir, configEnvironment)
+        val result =
+            if (application.isDispatchThread) {
+                logger.debug { "dispatch thread detected, loading env vars on current thread" }
+                runWithModalProgressBlocking(project, "Loading Mise Environment Variables") {
+                    MiseCommandLineHelper.getEnvVars(workDir, configEnvironment)
+                }
+            } else if (!application.isReadAccessAllowed) {
+                logger.debug { "no read lock detected, loading env vars on dispatch thread" }
+                var result: Result<Map<String, String>>? = null
+                application.invokeAndWait {
+                    logger.debug { "loading env vars on invokeAndWait" }
+                    runWithModalProgressBlocking(project, "Loading Mise Environment Variables") {
+                        result = MiseCommandLineHelper.getEnvVars(workDir, configEnvironment)
+                    }
+                }
+                result ?: throw ProcessCanceledException()
+            } else {
+                logger.debug { "unable to open the dialog. just load synchronously" }
+                MiseCommandLineHelper.getEnvVars(workDir, configEnvironment)
+            }
+
+        return result
             .fold(
                 onSuccess = { envVars -> envVars },
                 onFailure = {
@@ -41,4 +66,6 @@ object MiseHelper {
                 },
             )
     }
+
+    private val logger = Logger.getInstance(MiseHelper::class.java)
 }


### PR DESCRIPTION
- `SpringBootRunConfiguration` is calls the `RunConfigurationExtension.updateJavaParameters` on EDT with read-action.
- So opening the progress modal makes deadlock.
- Check the current thread's state and do the best option on the case. (The worst, synchronized loading)

Resolves: #259

- The SpringBootRunConfiguration calls the `RunConfigurationExtension.updateJavaParameters` on UI Thread.
- https://youtrack.jetbrains.com/issue/IJPL-14185/Threading-issues-with-RunConfigurationExtension
