### PR TITLE
fix: class `MnRunConfiguration` cannot be cast to class `GradleRunConfiguration`

### DIFF
--- a/modules/products/gradle/src/main/kotlin/com/github/l34130/mise/gradle/run/MiseGradleEnvironmentProvider.kt
+++ b/modules/products/gradle/src/main/kotlin/com/github/l34130/mise/gradle/run/MiseGradleEnvironmentProvider.kt
@@ -21,7 +21,7 @@ class MiseGradleEnvironmentProvider : GradleExecutionEnvironmentProvider {
         task: ExecuteRunConfigurationTask,
         executor: Executor,
     ): ExecutionEnvironment? {
-        val runProfile = task.runProfile as GradleRunConfiguration
+        val runProfile = task.runProfile as? GradleRunConfiguration ?: return null
         var environment: ExecutionEnvironment? = delegateProvider(task)?.createExecutionEnvironment(project, task, executor)
 
         // No registered environment provider. Gradle Task is in this case.


### PR DESCRIPTION
- #268 