### PR TITLE
feat: add support for args in run configurations

### DIFF
--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/execution/configuration/MiseTomlTaskRunConfiguration.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/execution/configuration/MiseTomlTaskRunConfiguration.kt
@@ -55,6 +55,7 @@ class MiseTomlTaskRunConfiguration(
                     params += listOf("--env", miseConfigEnvironment)
                 }
                 params += listOf("run", miseTaskName)
+                params += "--"
                 params += ParametersListUtil.parse(taskParams)
 
                 val commandLine = PtyCommandLine()

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/execution/configuration/MiseTomlTaskRunConfiguration.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/execution/configuration/MiseTomlTaskRunConfiguration.kt
@@ -22,6 +22,7 @@ import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.vfs.encoding.EncodingManager
 import com.intellij.util.EnvironmentUtil
 import com.intellij.util.application
+import com.intellij.util.execution.ParametersListUtil
 import org.jdom.Element
 
 class MiseTomlTaskRunConfiguration(
@@ -36,6 +37,7 @@ class MiseTomlTaskRunConfiguration(
     var miseTaskName: String = ""
     var workingDirectory: String? = project.basePath
     var envVars: EnvironmentVariablesData = EnvironmentVariablesData.DEFAULT
+    var taskParams: String = ""
 
     override fun getState(
         executor: Executor,
@@ -53,6 +55,7 @@ class MiseTomlTaskRunConfiguration(
                     params += listOf("--env", miseConfigEnvironment)
                 }
                 params += listOf("run", miseTaskName)
+                params += ParametersListUtil.parse(taskParams)
 
                 val commandLine = PtyCommandLine()
                 if (!SystemInfo.isWindows) {
@@ -85,6 +88,7 @@ class MiseTomlTaskRunConfiguration(
         child.setAttribute("configEnvironment", miseConfigEnvironment ?: "")
         child.setAttribute("taskName", miseTaskName)
         child.setAttribute("workingDirectory", workingDirectory ?: "")
+        child.setAttribute("taskParams", taskParams)
         envVars.writeExternal(child)
     }
 
@@ -94,6 +98,7 @@ class MiseTomlTaskRunConfiguration(
         miseConfigEnvironment = child.getAttributeValue("configEnvironment")
         miseTaskName = child.getAttributeValue("taskName") ?: ""
         workingDirectory = child.getAttributeValue("workingDirectory")
+        taskParams = child.getAttributeValue("taskParams") ?: ""
         envVars = EnvironmentVariablesData.readExternal(child)
     }
 }

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/execution/configuration/MiseTomlTaskRunConfigurationEditor.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/execution/configuration/MiseTomlTaskRunConfigurationEditor.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
 import com.intellij.openapi.options.SettingsEditor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.TextFieldWithBrowseButton
+import com.intellij.ui.RawCommandLineEditor
 import com.intellij.ui.components.JBTextField
 import com.intellij.ui.dsl.builder.AlignX
 import com.intellij.ui.dsl.builder.panel
@@ -20,6 +21,7 @@ class MiseTomlTaskRunConfigurationEditor(
 
     private val miseConfigEnvironmentTf = JBTextField()
     private val miseTaskNameTf = JBTextField()
+    private val miseTaskArgsComponent = RawCommandLineEditor()
     private val workingDirectoryTf = TextFieldWithBrowseButton()
     private val envVarsComponent = EnvironmentVariablesComponent()
 
@@ -40,6 +42,9 @@ class MiseTomlTaskRunConfigurationEditor(
             row("Mise task name:") {
                 cell(miseTaskNameTf).align(AlignX.FILL)
             }
+            row("Mise task arguments:") {
+                cell(miseTaskArgsComponent).align(AlignX.FILL)
+            }
             row("Working directory:") {
                 cell(workingDirectoryTf).align(AlignX.FILL)
             }
@@ -53,6 +58,7 @@ class MiseTomlTaskRunConfigurationEditor(
     override fun resetEditorFrom(configuration: MiseTomlTaskRunConfiguration) {
         miseConfigEnvironmentTf.text = configuration.miseConfigEnvironment
         miseTaskNameTf.text = configuration.miseTaskName
+        miseTaskArgsComponent.text = configuration.taskParams
         workingDirectoryTf.text = configuration.workingDirectory ?: ""
         envVarsComponent.envData = configuration.envVars
     }
@@ -62,5 +68,6 @@ class MiseTomlTaskRunConfigurationEditor(
         configuration.miseTaskName = miseTaskNameTf.text
         configuration.workingDirectory = workingDirectoryTf.text
         configuration.envVars = envVarsComponent.envData
+        configuration.taskParams = miseTaskArgsComponent.text
     }
 }


### PR DESCRIPTION
I have a task [file task](https://mise.jdx.dev/tasks/file-tasks.html) `dev` that supports receiving `--dbg` argument and I realized run configurations didn't accepted arguments.

So I added support for setting up an argument list to be passed on to the mise task.