### PR TITLE
feat(pycharm): support mise env vars in Python Console

### DIFF
--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/MiseHelper.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/MiseHelper.kt
@@ -19,12 +19,11 @@ import com.intellij.platform.ide.progress.runWithModalProgressBlocking
 import com.intellij.util.application
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
-import java.util.function.Supplier
 
 object MiseHelper {
     fun getMiseEnvVarsOrNotify(
         configuration: RunConfigurationBase<*>,
-        workingDirectory: Supplier<String?>,
+        workingDirectory: String?,
     ): Map<String, String> {
         val project = configuration.project
         val projectState = project.service<MiseProjectSettings>().state
@@ -38,7 +37,7 @@ object MiseHelper {
             when {
                 isRunConfigDisabled -> return emptyMap()
                 useOverrideSettings -> {
-                    val workDir = workingDirectory.get()?.takeIf { it.isNotBlank() } ?: project.basePath
+                    val workDir = workingDirectory?.takeIf { it.isNotBlank() } ?: project.basePath
                     workDir to runConfigState.miseConfigEnvironment
                 }
                 useProjectSettings -> project.basePath to projectState.miseConfigEnvironment

--- a/modules/products/clion/src/main/kotlin/com/github/l34130/mise/clion/run/MiseCidrRunConfigurationExtension.kt
+++ b/modules/products/clion/src/main/kotlin/com/github/l34130/mise/clion/run/MiseCidrRunConfigurationExtension.kt
@@ -51,7 +51,7 @@ class MiseCidrRunConfigurationExtension : CidrRunConfigurationExtensionBase() {
         context: ConfigurationExtensionContext,
     ) {
         MiseHelper
-            .getMiseEnvVarsOrNotify(configuration, configuration::getWorkingDirectory)
+            .getMiseEnvVarsOrNotify(configuration, configuration.getWorkingDirectory())
             .forEach { (k, v) -> cmdLine.withEnvironment(k, v) }
     }
 }

--- a/modules/products/goland/src/main/kotlin/com/github/l34130/mise/goland/run/MiseGoLandRunConfigurationExtension.kt
+++ b/modules/products/goland/src/main/kotlin/com/github/l34130/mise/goland/run/MiseGoLandRunConfigurationExtension.kt
@@ -40,7 +40,7 @@ class MiseGoLandRunConfigurationExtension : GoRunConfigurationExtension() {
         commandLineType: GoRunningState.CommandLineType,
     ) {
         MiseHelper
-            .getMiseEnvVarsOrNotify(configuration, configuration::getWorkingDirectory)
+            .getMiseEnvVarsOrNotify(configuration, configuration.getWorkingDirectory())
             .forEach { (k, v) -> cmdLine.addEnvironmentVariable(k, v) }
     }
 

--- a/modules/products/gradle/src/main/kotlin/com/github/l34130/mise/gradle/run/MiseGradleEnvironmentProvider.kt
+++ b/modules/products/gradle/src/main/kotlin/com/github/l34130/mise/gradle/run/MiseGradleEnvironmentProvider.kt
@@ -49,7 +49,7 @@ class MiseGradleEnvironmentProvider : GradleExecutionEnvironmentProvider {
             val miseEnvVars =
                 MiseHelper.getMiseEnvVarsOrNotify(
                     configuration = runProfile,
-                    workingDirectory = { runProfile.projectPathOnTarget },
+                    workingDirectory = runProfile.projectPathOnTarget,
                 )
 
             val settings = (environment.runProfile as GradleRunConfiguration).settings

--- a/modules/products/idea/src/main/kotlin/com/github/l34130/mise/idea/run/MiseIdeaRunConfigurationExtension.kt
+++ b/modules/products/idea/src/main/kotlin/com/github/l34130/mise/idea/run/MiseIdeaRunConfigurationExtension.kt
@@ -44,7 +44,7 @@ class MiseIdeaRunConfigurationExtension : RunConfigurationExtension() {
         params: JavaParameters,
         runnerSettings: RunnerSettings?,
     ) {
-        val envVars = MiseHelper.getMiseEnvVarsOrNotify(configuration, params::getWorkingDirectory)
+        val envVars = MiseHelper.getMiseEnvVarsOrNotify(configuration, params.getWorkingDirectory())
         params.env = params.env + envVars
 
         // Gradle support (and external system configuration)

--- a/modules/products/nodejs/src/main/kotlin/com/github/l34130/mise/nodejs/run/MiseNodeRunConfigurationExtension.kt
+++ b/modules/products/nodejs/src/main/kotlin/com/github/l34130/mise/nodejs/run/MiseNodeRunConfigurationExtension.kt
@@ -44,12 +44,11 @@ class MiseNodeRunConfigurationExtension : AbstractNodeRunConfigurationExtension(
         val envVars =
             MiseHelper.getMiseEnvVarsOrNotify(
                 configuration = configuration,
-                workingDirectory = {
+                workingDirectory =
                     when (configuration) {
                         is NodeJsRunConfiguration -> configuration.workingDirectory
                         else -> null
-                    }
-                },
+                    },
             )
 
         return object : NodeRunConfigurationLaunchSession() {

--- a/modules/products/pycharm/src/main/kotlin/com/github/l34130/mise/pycharm/run/MisePythonCommandLineTargetEnvironmentProvider.kt
+++ b/modules/products/pycharm/src/main/kotlin/com/github/l34130/mise/pycharm/run/MisePythonCommandLineTargetEnvironmentProvider.kt
@@ -20,7 +20,7 @@ class MisePythonCommandLineTargetEnvironmentProvider : PythonCommandLineTargetEn
             if (runParams is AbstractPythonRunConfiguration<*>) {
                 MiseHelper.getMiseEnvVarsOrNotify(
                     configuration = runParams,
-                    workingDirectory = { runParams.workingDirectory },
+                    workingDirectory = runParams.workingDirectory,
                 )
             } else {
                 // For python script or python console which do not have RunConfiguration

--- a/modules/products/pycharm/src/main/kotlin/com/github/l34130/mise/pycharm/run/MisePythonRunConfigurationExtension.kt
+++ b/modules/products/pycharm/src/main/kotlin/com/github/l34130/mise/pycharm/run/MisePythonRunConfigurationExtension.kt
@@ -48,7 +48,7 @@ class MisePythonRunConfigurationExtension : PythonRunConfigurationExtension() {
         val envVars =
             MiseHelper.getMiseEnvVarsOrNotify(
                 configuration = runConfiguration,
-                workingDirectory = { runConfiguration.workingDirectory },
+                workingDirectory = runConfiguration.workingDirectory,
             )
 
         cmdLine.withEnvironment(envVars)

--- a/modules/products/ruby/src/main/kotlin/com/github/l34130/mise/ruby/run/MiseRubyMineRunConfigurationExtension.kt
+++ b/modules/products/ruby/src/main/kotlin/com/github/l34130/mise/ruby/run/MiseRubyMineRunConfigurationExtension.kt
@@ -46,7 +46,7 @@ class MiseRubyMineRunConfigurationExtension : RubyRunConfigurationExtension() {
         runnerId: String,
     ) {
         MiseHelper
-            .getMiseEnvVarsOrNotify(configuration, configuration::getWorkingDirectory)
+            .getMiseEnvVarsOrNotify(configuration, configuration.getWorkingDirectory())
             .forEach { (k, v) -> cmdLine.withEnvironment(k, v) }
     }
 }


### PR DESCRIPTION
Fixes #374

## Summary
- Extend `PythonCommandLineTargetEnvironmentProvider` to inject mise env vars for Python/Flask Console
- Previously only worked for run configurations, now works for console too

## Test plan
- Enable mise in Tools → Mise Settings
- Create `mise.toml` with env vars
- Open Python Console
- Verify env vars available via `os.environ.get('VAR')`

Here's the behaviour after the change:
<img width="1644" height="1244" alt="CleanShot 2025-12-11 at 10 26 28" src="https://github.com/user-attachments/assets/e9162aa7-7daa-4d67-9906-61d10d1cc735" />
