### PR TITLE
fix: prevent deadlock when write action is in progress

### DIFF
--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/util/Threading.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/util/Threading.kt
@@ -1,5 +1,7 @@
 package com.github.l34130.mise.core.util
 
+import com.intellij.openapi.application.ex.ApplicationEx
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.Logger
 
 private val logger = Logger.getInstance("com.github.l34130.mise.core.util.Threading")
@@ -8,6 +10,8 @@ private val logger = Logger.getInstance("com.github.l34130.mise.core.util.Thread
  * Checks if it's safe to perform operations that might need EDT access or project context.
  *
  * Returns false if:
+ * - A write action is in progress (ReadAction would deadlock if called from a
+ *   PotemkinProgress background thread while EDT holds the write lock)
  * - We're in a coroutine dispatcher thread (may cause deadlocks)
  * - We're in WSL infrastructure operations (internal IDE setup)
  * - We're in IJent deployment operations
@@ -16,12 +20,22 @@ private val logger = Logger.getInstance("com.github.l34130.mise.core.util.Thread
  * When unsafe, callers should skip operations or use alternative approaches.
  *
  * This prevents:
+ * - Deadlocks from ReadAction in PotemkinProgress background threads (#413)
  * - Deadlocks from invokeAndWait in coroutine contexts
  * - Threading issues during IDE infrastructure initialization
  * - Project detection failures in unsafe threading contexts
  * - Recursive environment customization during WSL/IJent setup
  */
 fun canSafelyInvokeAndWait(): Boolean {
+    // If a write action is in progress on another thread, any ReadAction attempt
+    // from this thread will block waiting for the write lock to be released.
+    // This causes deadlocks when EDT holds a write lock and spawns a PotemkinProgress
+    // background thread that ends up here (e.g., git index refresh → git command → env customizer).
+    if ((ApplicationManager.getApplication() as? ApplicationEx)?.isWriteActionInProgress == true) {
+        logger.trace("Write action in progress on another thread, cannot safely acquire read lock")
+        return false
+    }
+
     val threadName = Thread.currentThread().name
 
     // Coroutine dispatcher threads cannot safely call invokeAndWait


### PR DESCRIPTION
## Summary

- Fixes #413: deadlock when EDT holds a write lock (e.g., saving a `GitIndexVirtualFile`) and spawns a PotemkinProgress background thread that triggers `MiseCommandLineEnvCustomizer`
- Adds `ApplicationEx.isWriteActionInProgress` check to `canSafelyInvokeAndWait()` so environment customization is skipped when a write action is held, breaking the deadlock chain

## Test plan

- [ ] Open a project with mise configured
- [ ] Trigger a file save that causes a git index refresh (e.g., save a file tracked by git staging area)
- [ ] Verify no hang/deadlock occurs
- [ ] Verify mise environment customization still works for normal command executions

🤖 Generated with [Claude Code](https://claude.com/claude-code)