### PR TITLE
support mise environment caching

### DIFF
--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/command/MiseCommandLine.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/command/MiseCommandLine.kt
@@ -2,6 +2,7 @@ package com.github.l34130.mise.core.command
 
 import com.fasterxml.jackson.core.type.TypeReference
 import com.github.l34130.mise.core.command.MiseCommandLineHelper.environmentSkipCustomization
+import com.github.l34130.mise.core.command.MiseEnvCacheKeyService.Companion.MISE_ENV_CACHE_KEY
 import com.github.l34130.mise.core.util.guessMiseProjectPath
 import com.intellij.execution.ExecutionException
 import com.intellij.execution.configurations.GeneralCommandLine
@@ -104,7 +105,14 @@ internal class MiseCommandLine(
     ): Result<String> {
         val generalCommandLine = GeneralCommandLine(commandLineArgs).withWorkDirectory(workingDir.ifBlank { null })
         environmentSkipCustomization(generalCommandLine.environment)
+        injectMiseEnvCacheEnvironment(generalCommandLine.environment)
         return runCommandLineInternal(generalCommandLine)
+    }
+
+    private fun injectMiseEnvCacheEnvironment(environment: MutableMap<String?, String?>) {
+        if (environment[MISE_ENV_CACHE_KEY].isNullOrBlank()) {
+            environment[MISE_ENV_CACHE_KEY] = project.service<MiseEnvCacheKeyService>().sessionKey
+        }
     }
 
     @RequiresBackgroundThread

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/command/MiseEnvCacheKeyService.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/command/MiseEnvCacheKeyService.kt
@@ -1,0 +1,35 @@
+package com.github.l34130.mise.core.command
+
+import com.intellij.openapi.components.Service
+import java.security.SecureRandom
+import java.util.Base64
+
+/**
+ * Provides a stable cache session key for all plugin-owned mise invocations within a project session.
+ *
+ * Rationale:
+ * - The plugin launches mise as separate subprocesses, not a persistent shell.
+ * - mise env caching is session-keyed via `__MISE_ENV_CACHE_KEY`.
+ * - Reusing one key across plugin subprocesses allows cache hits for repeated env resolution
+ *   (including fnox-backed env plugins), while still rotating on IDE/project session restart.
+ *
+ * References:
+ * - fnox mise integration: https://fnox.jdx.dev/guide/mise-integration.html
+ * - mise env cache settings: https://mise.jdx.dev/configuration/settings.html#env_cache
+ */
+@Service(Service.Level.PROJECT)
+class MiseEnvCacheKeyService {
+    companion object {
+        const val MISE_ENV_CACHE_KEY = "__MISE_ENV_CACHE_KEY"
+    }
+
+    private val rng = SecureRandom()
+
+    val sessionKey: String = generate()
+
+    private fun generate(): String {
+        val key = ByteArray(32) // 256-bit
+        rng.nextBytes(key)
+        return Base64.getEncoder().encodeToString(key)
+    }
+}

--- a/modules/core/src/test/kotlin/com/github/l34130/mise/core/command/MiseCommandLineTest.kt
+++ b/modules/core/src/test/kotlin/com/github/l34130/mise/core/command/MiseCommandLineTest.kt
@@ -1,0 +1,63 @@
+package com.github.l34130.mise.core.command
+
+import com.github.l34130.mise.core.cache.MiseCacheService
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.process.ProcessOutput
+import com.intellij.openapi.components.service
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+
+class MiseCommandLineTest : BasePlatformTestCase() {
+    private fun processOutput(stdout: String = "", stderr: String = "", exitCode: Int = 0): ProcessOutput {
+        val output = ProcessOutput()
+        output.appendStdout(stdout)
+        output.appendStderr(stderr)
+        output.exitCode = exitCode
+        return output
+    }
+
+    private fun <T> withCommandLineExecutor(
+        executor: (GeneralCommandLine, Int) -> ProcessOutput,
+        block: () -> T
+    ): T {
+        val previous = MiseCommandLine.commandLineExecutor
+        MiseCommandLine.commandLineExecutor = MiseCommandLineExecutor { generalCommandLine, timeout ->
+            executor(generalCommandLine, timeout)
+        }
+        return try {
+            block()
+        } finally {
+            MiseCommandLine.commandLineExecutor = previous
+        }
+    }
+
+    private fun seedExecutableInfo(path: String = "mise", version: MiseVersion = MiseVersion(2026, 1, 1)) {
+        val cacheService = project.service<MiseCacheService>()
+        cacheService.invalidateAllExecutables()
+        cacheService.getOrComputeExecutable(MiseExecutableManager.EXECUTABLE_KEY) {
+            MiseExecutableInfo(path = path, version = version)
+        }
+    }
+
+    fun `test runRawCommandLine injects stable mise env cache session key`() {
+        seedExecutableInfo()
+        val environments = mutableListOf<Map<String, String?>>()
+
+        withCommandLineExecutor(
+            executor = { commandLine, _ ->
+                environments += commandLine.environment.toMap()
+                processOutput(stdout = "ok")
+            },
+        ) {
+            val commandLine = MiseCommandLine(project, project.basePath, null)
+            commandLine.runRawCommandLine(listOf("env", "--json")).getOrThrow()
+            commandLine.runRawCommandLine(listOf("ls", "--local", "--json")).getOrThrow()
+        }
+
+        assertEquals(2, environments.size)
+        val first = environments[0]
+        val second = environments[1]
+
+        assertFalse(first["__MISE_ENV_CACHE_KEY"].isNullOrBlank())
+        assertEquals(first["__MISE_ENV_CACHE_KEY"], second["__MISE_ENV_CACHE_KEY"])
+    }
+}


### PR DESCRIPTION
Inject a stable `__MISE_ENV_CACHE_KEY` for plugin-owned mise subprocesses so separate invocations can share mise's environment cache within an IDE session.

This aligns with mise environment caching behavior: https://mise.jdx.dev/cache-behavior.html#environment-caching

Implementation details:
- add project-scoped `MiseEnvCacheKeyService`
- generate a 256-bit key once per project session
- inject key in `MiseCommandLine` for all plugin-owned mise commands