### PR TITLE
diagram: Prevent IDE freeze when showing task graph model

### DIFF
--- a/modules/products/diagram/src/main/kotlin/com/github/l34130/mise/diagram/AbstractMiseTaskGraphDataModel.kt
+++ b/modules/products/diagram/src/main/kotlin/com/github/l34130/mise/diagram/AbstractMiseTaskGraphDataModel.kt
@@ -1,0 +1,137 @@
+package com.github.l34130.mise.diagram
+
+import com.intellij.diagram.DiagramDataModel
+import com.intellij.diagram.DiagramEdge
+import com.intellij.diagram.DiagramNode
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Disposer
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Shared async data model for Mise task graph diagrams.
+ *
+ * This prevents EDT hangs by computing nodes on a pooled thread, and standardizes refresh/update behavior.
+ * Diagrams open empty and refresh once computation finishes.
+ */
+abstract class AbstractMiseTaskGraphDataModel(
+    project: Project,
+    provider: MiseTaskGraphProvider,
+) : DiagramDataModel<MiseTaskGraphable>(project, provider) {
+    @Volatile
+    protected var nodes: List<MiseTaskGraphNode> = emptyList()
+
+    private val isDisposed = AtomicBoolean(false)
+    private val generation = AtomicInteger(0)
+    private val registeredWithBuilder = AtomicBoolean(false)
+
+    private enum class EdgeDirection { INTO_NODE, OUT_OF_NODE }
+
+    init {
+        ApplicationManager.getApplication().invokeLater { reloadAsync() }
+    }
+
+    override fun getNodes(): Collection<DiagramNode<MiseTaskGraphable>?> = nodes
+
+    override fun getNodeName(node: DiagramNode<MiseTaskGraphable>): String =
+        when (val element = node.identifyingElement) {
+            is MiseTaskGraphableTaskWrapper<*> -> element.task.name
+            is MiseTaskGraphableTomlFile -> element.tomlFile.name
+            DefaultMiseTaskGraphable -> "Mise Task graph"
+        }
+
+    /**
+     * Builds diagram edges for the given task graph [nodes].
+     *
+     * This function resolves dependency references by **task name**:
+     * - `depends` and `waitFor` create an edge **from the dependency to the current task**.
+     * - `dependsPost` creates an edge **from the current task to the post-dependency**.
+     *
+     * ### Task name uniqueness
+     * In most cases task names should be unique within [nodes]. If duplicates ever occur, the behavior is kept
+     * consistent with the original implementation that used `nodes.find { ... }`:
+     *
+     * - We keep the **first** node encountered for a given task name (`putIfAbsent`), i.e. "first wins".
+     * - This avoids subtle changes where a `Map` built with `associateBy` would make the **last** duplicate win.
+     *
+     * Unresolvable dependency names (no node with that name) are ignored.
+     */
+    override fun getEdges(): Collection<DiagramEdge<MiseTaskGraphable>> {
+        val nodeByTaskName = buildMap {
+            for (n in nodes) {
+                val name = (n.identifyingElement as MiseTaskGraphableTaskWrapper<*>).task.name
+                putIfAbsent(name, n) // preserves first occurrence, matching the original `find` logic
+            }
+        }
+
+        return buildList {
+            for (taskGraphNode in nodes) {
+                val task = (taskGraphNode.identifyingElement as MiseTaskGraphableTaskWrapper<*>).task
+
+                val edgeSpecifications: List<Pair<List<String>, EdgeDirection>> =
+                    listOf(
+                        task.depends?.map { it.first() }.orEmpty() to EdgeDirection.INTO_NODE,
+                        task.waitFor?.map { it.first() }.orEmpty() to EdgeDirection.INTO_NODE,
+                        task.dependsPost?.map { it.first() }.orEmpty() to EdgeDirection.OUT_OF_NODE,
+                    )
+
+                for ((names, direction) in edgeSpecifications) {
+                    for (name in names) {
+                        val target = nodeByTaskName[name] ?: continue
+                        add(
+                            when (direction) {
+                                EdgeDirection.OUT_OF_NODE -> MiseTaskGraphEdge(taskGraphNode, target)
+                                EdgeDirection.INTO_NODE -> MiseTaskGraphEdge(target, taskGraphNode)
+                            },
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    override fun refreshDataModel() {
+        reloadAsync()
+    }
+
+    override fun dispose() {
+        isDisposed.set(true)
+    }
+
+    protected abstract fun computeNodesBlocking(): List<MiseTaskGraphNode>
+
+    protected open fun configurePresentationBeforeRefresh() {
+        // default no-op
+    }
+
+    private fun reloadAsync() {
+        if (isDisposed.get() || project.isDisposed) return
+        val currentGeneration = generation.incrementAndGet()
+        val app = ApplicationManager.getApplication()
+        app.executeOnPooledThread {
+            if (isDisposed.get() || project.isDisposed) return@executeOnPooledThread
+            val computedNodes = computeNodesBlocking()
+            app.invokeLater {
+                if (isDisposed.get() || project.isDisposed) return@invokeLater
+                if (generation.get() != currentGeneration) return@invokeLater
+                nodes = computedNodes
+
+                val currentBuilder = runCatching { builder }.getOrNull() ?: return@invokeLater
+
+                if (registeredWithBuilder.compareAndSet(false, true)) {
+                    // Ensure our model is disposed when the diagram builder is disposed.
+                    Disposer.register(currentBuilder, this)
+                }
+
+                configurePresentationBeforeRefresh()
+                currentBuilder
+                    .queryUpdate()
+                    .withRelayout()
+                    .withDataReload()
+                    .withPresentationUpdate()
+                    .run()
+            }
+        }
+    }
+}

--- a/modules/products/diagram/src/main/kotlin/com/github/l34130/mise/diagram/MiseFileTaskGraphDataModel.kt
+++ b/modules/products/diagram/src/main/kotlin/com/github/l34130/mise/diagram/MiseFileTaskGraphDataModel.kt
@@ -2,8 +2,6 @@ package com.github.l34130.mise.diagram
 
 import com.github.l34130.mise.core.MiseTaskResolver
 import com.github.l34130.mise.core.model.MiseTomlTableTask
-import com.intellij.diagram.DiagramDataModel
-import com.intellij.diagram.DiagramEdge
 import com.intellij.diagram.DiagramNode
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
@@ -13,10 +11,19 @@ import kotlinx.coroutines.runBlocking
 
 class MiseFileTaskGraphDataModel(
     project: Project,
-    tomlFile: MiseTaskGraphableTomlFile,
+    private val tomlFile: MiseTaskGraphableTomlFile,
     provider: MiseTaskGraphProvider,
-) : DiagramDataModel<MiseTaskGraphable>(project, provider) {
-    private val nodes: List<MiseTaskGraphNode> =
+) : AbstractMiseTaskGraphDataModel(project, provider) {
+
+    override fun getModificationTracker(): ModificationTracker = PsiManager.getInstance(project).modificationTracker
+
+    override fun getNodeName(node: DiagramNode<MiseTaskGraphable>): String =
+        (node.identifyingElement as? MiseTaskGraphableTaskWrapper<*>)?.task?.name
+            ?: super.getNodeName(node)
+
+    override fun addElement(element: MiseTaskGraphable?): DiagramNode<MiseTaskGraphable>? = null
+
+    override fun computeNodesBlocking(): List<MiseTaskGraphNode> =
         mutableListOf<MiseTaskGraphNode>()
             .apply {
                 val myTasks = MiseTomlTableTask.resolveAllFromTomlFile(tomlFile.tomlFile)
@@ -52,38 +59,4 @@ class MiseFileTaskGraphDataModel(
                     },
                 )
             }.distinctBy { (it.identifyingElement as MiseTaskGraphableTaskWrapper<*>).task.name }
-
-    override fun getModificationTracker(): ModificationTracker = PsiManager.getInstance(project).modificationTracker
-
-    override fun getNodes(): Collection<DiagramNode<MiseTaskGraphable>?> = nodes
-
-    override fun getNodeName(node: DiagramNode<MiseTaskGraphable>): String = "" // node.identifyingElement.name
-
-    override fun addElement(element: MiseTaskGraphable?): DiagramNode<MiseTaskGraphable>? = null
-
-    override fun getEdges(): Collection<DiagramEdge<MiseTaskGraphable>> {
-        val result = mutableListOf<MiseTaskGraphEdge>()
-
-        for (node in nodes) {
-            val task = (node.identifyingElement as MiseTaskGraphableTaskWrapper<*>).task
-
-            for (item in task.depends?.map { it.first() } ?: emptyList()) {
-                val target = nodes.find { (it.identifyingElement as MiseTaskGraphableTaskWrapper<*>).task.name == item } ?: continue
-                result.add(MiseTaskGraphEdge(target, node))
-            }
-            for (item in task.waitFor?.map { it.first() } ?: emptyList()) {
-                val target = nodes.find { (it.identifyingElement as MiseTaskGraphableTaskWrapper<*>).task.name == item } ?: continue
-                result.add(MiseTaskGraphEdge(target, node))
-            }
-            for (item in task.dependsPost?.map { it.first() } ?: emptyList()) {
-                val target = nodes.find { (it.identifyingElement as MiseTaskGraphableTaskWrapper<*>).task.name == item } ?: continue
-                result.add(MiseTaskGraphEdge(node, target))
-            }
-        }
-
-        return result
-    }
-
-    override fun dispose() {
-    }
 }

--- a/modules/products/diagram/src/main/kotlin/com/github/l34130/mise/diagram/MiseFullTaskGraphDataModel.kt
+++ b/modules/products/diagram/src/main/kotlin/com/github/l34130/mise/diagram/MiseFullTaskGraphDataModel.kt
@@ -1,8 +1,6 @@
 package com.github.l34130.mise.diagram
 
 import com.github.l34130.mise.core.MiseTaskResolver
-import com.intellij.diagram.DiagramDataModel
-import com.intellij.diagram.DiagramEdge
 import com.intellij.diagram.DiagramNode
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
@@ -13,46 +11,21 @@ import kotlinx.coroutines.runBlocking
 class MiseFullTaskGraphDataModel(
     project: Project,
     provider: MiseTaskGraphProvider,
-) : DiagramDataModel<MiseTaskGraphable>(project, provider) {
-    private val nodes: List<MiseTaskGraphNode> =
+) : AbstractMiseTaskGraphDataModel(project, provider) {
+
+    override fun getModificationTracker(): ModificationTracker = PsiManager.getInstance(project).modificationTracker
+
+    override fun getNodeName(node: DiagramNode<MiseTaskGraphable>): String =
+        (node.identifyingElement as? MiseTaskGraphableTaskWrapper<*>)?.task?.name
+            ?: super.getNodeName(node)
+
+    override fun addElement(element: MiseTaskGraphable?): DiagramNode<MiseTaskGraphable>? = null
+
+    override fun computeNodesBlocking(): List<MiseTaskGraphNode> =
         runBlocking {
             project
                 .service<MiseTaskResolver>()
                 .getMiseTasks()
                 .map { MiseTaskGraphNode(MiseTaskGraphableTaskWrapper(it), provider) }
         }
-
-    override fun getModificationTracker(): ModificationTracker = PsiManager.getInstance(project).modificationTracker
-
-    override fun getNodes(): Collection<DiagramNode<MiseTaskGraphable>?> = nodes
-
-    override fun getNodeName(node: DiagramNode<MiseTaskGraphable>): String = "" // node.identifyingElement.name
-
-    override fun addElement(element: MiseTaskGraphable?): DiagramNode<MiseTaskGraphable>? = null
-
-    override fun getEdges(): Collection<DiagramEdge<MiseTaskGraphable>> {
-        val result = mutableListOf<MiseTaskGraphEdge>()
-
-        for (node in nodes) {
-            val task = (node.identifyingElement as MiseTaskGraphableTaskWrapper<*>).task
-
-            for (item in task.depends?.map { it.first() } ?: emptyList()) {
-                val target = nodes.find { (it.identifyingElement as MiseTaskGraphableTaskWrapper<*>).task.name == item } ?: continue
-                result.add(MiseTaskGraphEdge(target, node))
-            }
-            for (item in task.waitFor?.map { it.first() } ?: emptyList()) {
-                val target = nodes.find { (it.identifyingElement as MiseTaskGraphableTaskWrapper<*>).task.name == item } ?: continue
-                result.add(MiseTaskGraphEdge(target, node))
-            }
-            for (item in task.dependsPost?.map { it.first() } ?: emptyList()) {
-                val target = nodes.find { (it.identifyingElement as MiseTaskGraphableTaskWrapper<*>).task.name == item } ?: continue
-                result.add(MiseTaskGraphEdge(node, target))
-            }
-        }
-
-        return result
-    }
-
-    override fun dispose() {
-    }
 }

--- a/modules/products/diagram/src/main/kotlin/com/github/l34130/mise/diagram/MiseSingleTaskGraphDataModel.kt
+++ b/modules/products/diagram/src/main/kotlin/com/github/l34130/mise/diagram/MiseSingleTaskGraphDataModel.kt
@@ -1,8 +1,6 @@
 package com.github.l34130.mise.diagram
 
 import com.github.l34130.mise.core.MiseTaskResolver
-import com.intellij.diagram.DiagramDataModel
-import com.intellij.diagram.DiagramEdge
 import com.intellij.diagram.DiagramNode
 import com.intellij.openapi.components.service
 import com.intellij.openapi.graph.GraphLayoutOrientation
@@ -15,56 +13,16 @@ class MiseSingleTaskGraphDataModel(
     project: Project,
     private val myTask: MiseTaskGraphableTaskWrapper<*>,
     provider: MiseTaskGraphProvider,
-) : DiagramDataModel<MiseTaskGraphable>(project, provider) {
-    private var nodes: List<MiseTaskGraphNode> = loadNodes()
+) : AbstractMiseTaskGraphDataModel(project, provider) {
 
     override fun getModificationTracker(): ModificationTracker = PsiManager.getInstance(project).modificationTracker
-
-    override fun getNodes(): Collection<DiagramNode<MiseTaskGraphable>?> = nodes
 
     override fun getNodeName(node: DiagramNode<MiseTaskGraphable>): String =
         (node.identifyingElement as MiseTaskGraphableTaskWrapper<*>).task.name
 
     override fun addElement(element: MiseTaskGraphable?): DiagramNode<MiseTaskGraphable>? = null
 
-    override fun getEdges(): Collection<DiagramEdge<MiseTaskGraphable>> {
-        val result = mutableListOf<MiseTaskGraphEdge>()
-
-        for (node in nodes) {
-            val task = (node.identifyingElement as MiseTaskGraphableTaskWrapper<*>).task
-
-            for (item in task.depends?.map { it.first() } ?: emptyList()) {
-                val target = nodes.find { (it.identifyingElement as MiseTaskGraphableTaskWrapper<*>).task.name == item } ?: continue
-                result.add(MiseTaskGraphEdge(target, node))
-            }
-            for (item in task.waitFor?.map { it.first() } ?: emptyList()) {
-                val target = nodes.find { (it.identifyingElement as MiseTaskGraphableTaskWrapper<*>).task.name == item } ?: continue
-                result.add(MiseTaskGraphEdge(target, node))
-            }
-            for (item in task.dependsPost?.map { it.first() } ?: emptyList()) {
-                val target = nodes.find { (it.identifyingElement as MiseTaskGraphableTaskWrapper<*>).task.name == item } ?: continue
-                result.add(MiseTaskGraphEdge(node, target))
-            }
-        }
-
-        return result
-    }
-
-    override fun refreshDataModel() {
-        nodes = loadNodes()
-        builder.presentationModel.settings.currentLayoutOrientation = GraphLayoutOrientation.LEFT_TO_RIGHT
-        builder
-            .queryUpdate()
-            .withRelayout()
-            .withDataReload()
-            .withPresentationUpdate()
-            .run()
-    }
-
-    override fun dispose() {
-    }
-
-    private fun loadNodes(): List<MiseTaskGraphNode> =
+    override fun computeNodesBlocking(): List<MiseTaskGraphNode> =
         sequence {
             @Suppress("RunBlockingInSuspendFunction")
             val tasks = runBlocking { project.service<MiseTaskResolver>().getMiseTasks() }
@@ -92,4 +50,8 @@ class MiseSingleTaskGraphDataModel(
 
             yield(MiseTaskGraphNode(myTask, provider))
         }.toList()
+
+    override fun configurePresentationBeforeRefresh() {
+        builder.presentationModel.settings.currentLayoutOrientation = GraphLayoutOrientation.LEFT_TO_RIGHT
+    }
 }

--- a/modules/products/diagram/src/main/kotlin/com/github/l34130/mise/diagram/MiseTaskGraphProvider.kt
+++ b/modules/products/diagram/src/main/kotlin/com/github/l34130/mise/diagram/MiseTaskGraphProvider.kt
@@ -23,7 +23,7 @@ class MiseTaskGraphProvider : BaseDiagramProvider<MiseTaskGraphable>() {
                 setUmlProvider(this@MiseTaskGraphProvider)
             }
 
-            override fun findInDataContext(o: DataContext): MiseTaskGraphable? {
+            override fun findInDataContext(o: DataContext): MiseTaskGraphable {
                 CommonDataKeys.PSI_ELEMENT.getData(o)?.let { psiElement ->
                     MiseTomlTableTask.resolveFromInlineTableInTaskTable(psiElement)?.let { return MiseTaskGraphableTaskWrapper(it) }
                     MiseTomlTableTask.resolveFromTaskChainedTable(psiElement)?.let { return MiseTaskGraphableTaskWrapper(it) }
@@ -36,7 +36,7 @@ class MiseTaskGraphProvider : BaseDiagramProvider<MiseTaskGraphable>() {
                     }
                 }
                 return DefaultMiseTaskGraphable
-            }
+        }
 
             override fun isContainerFor(
                 container: MiseTaskGraphable?,
@@ -72,7 +72,12 @@ class MiseTaskGraphProvider : BaseDiagramProvider<MiseTaskGraphable>() {
         }
     private val vfsResolver: DiagramVfsResolver<MiseTaskGraphable> =
         object : DiagramVfsResolver<MiseTaskGraphable> {
-            override fun getQualifiedName(element: MiseTaskGraphable?): String? = null
+            override fun getQualifiedName(element: MiseTaskGraphable?): String? =
+                when (element) {
+                    is MiseTaskGraphableTaskWrapper<*> -> element.task.name
+                    is MiseTaskGraphableTomlFile -> element.tomlFile.virtualFile?.path ?: element.tomlFile.name
+                    DefaultMiseTaskGraphable, null -> "mise-task-graph"
+                }
 
             override fun resolveElementByFQN(
                 element: String,


### PR DESCRIPTION
This PR refactors the Mise Task Graph diagram data models to compute nodes off the EDT and standardizes refresh/update behavior across the full/file/single-task diagrams. It also fixes diagram UX issues caused by unstable node identity and missing diagram element qualified names.

## What changed
- Introduced a shared `AbstractMiseTaskGraphDataModel` that:
    - computes nodes asynchronously on a pooled thread to avoid UI hangs
    - applies results on the EDT with generation checks to prevent stale updates
    - centralizes edge construction for `depends`, `waitFor`, and `dependsPost`
    - registers itself under the diagram builder’s disposable hierarchy to prevent updates after disposal
- Migrated `MiseFullTaskGraphDataModel`, `MiseFileTaskGraphDataModel`, and `MiseSingleTaskGraphDataModel` to extend the shared base class.
- Ensured diagram nodes have stable, non-empty names (required for reliable graph layout).
- Implemented `DiagramVfsResolver.getQualifiedName()` so diagram tabs no longer show `…/null` and the diagram has a stable identity.

## User-visible impact
- Opening the task graph diagram no longer risks freezing the IDE during node computation.
- Diagram titles/tabs show a meaningful identifier instead of `null`.
- Diagram layout is more stable thanks to consistent node naming.

## Testing
- Opened “Show Mise Task Graph Diagram” in a project with tasks and dependencies.
- Verified diagrams render without exceptions, labels are visible, and the tab title is no longer `…/null`.
- Verified refresh updates occur after background computation completes without blocking the UI.

Fixes #428