### PR TITLE
core: avoid VFS refresh during startup prewarm

### DIFF
--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/util/Project.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/util/Project.kt
@@ -65,7 +65,7 @@ fun Project.guessMiseProjectDir(): VirtualFile {
     if (projectDir != null) return projectDir
 
     val userHome = SystemProperties.getUserHome()
-    val userHomeDir = LocalFileSystem.getInstance().refreshAndFindFileByPath(userHome)
+    val userHomeDir = LocalFileSystem.getInstance().findFileByPath(userHome)
     checkNotNull(userHomeDir) {
         "Project has no base directory and user home is unavailable. project=${this.name}, userHome=$userHome"
     }


### PR DESCRIPTION
**Summary**
Avoid early VFS refresh during startup prewarm by switching `refreshAndFindFileByPath` to `findFileByPath` when falling back to user home. This prevents LoadingState violations before `COMPONENTS_LOADED`.

**Problem**
IDE logs emit `Should be called at least in the state COMPONENTS_LOADED, the current state is: CONFIGURATION_STORE_INITIALIZED` when VFS refresh is triggered too early during project initialization.

**Solution**
Use a non-refreshing lookup for the user home directory to avoid triggering VFS refresh during startup.

**Fixes**
Fixes #432.