### PR TITLE
wsl: `convertToolPathForWsl` explicitly require a path to determine distribution from

### DIFF
--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/wsl/WslPathUtils.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/wsl/WslPathUtils.kt
@@ -1,18 +1,15 @@
 package com.github.l34130.mise.core.wsl
 
 import com.github.l34130.mise.core.command.MiseDevTool
-import com.github.l34130.mise.core.setting.MiseApplicationSettings
 import com.github.l34130.mise.core.util.getUserHomeForProject
 import com.github.l34130.mise.core.util.getWslDistribution
 import com.github.l34130.mise.core.wsl.WslPathUtils.convertUnixPathForWsl
 import com.intellij.execution.wsl.WslDistributionManager
 import com.intellij.execution.wsl.WslPath
-import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.util.SystemInfo
-import com.intellij.util.application
+import com.intellij.openapi.util.io.FileUtil
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -248,26 +245,15 @@ object WslPathUtils {
      * On Windows, attempts to detect WSL context from the executable path and convert accordingly.
      *
      * @param unixPath The Unix path to convert
-     * @param executablePath The executable path to infer distribution from (optional)
+     * @param basePath A path within the project to infer distribution from (e.g., the path to the tool's executable or a project path)
      * @return The converted path (Windows UNC path for WSL, original path otherwise)
      * @throws IllegalStateException if distribution cannot be detected or path is not accessible
      */
-    fun convertUnixPathForWsl(unixPath: String, executablePath: String? = null): String {
+    fun convertUnixPathForWsl(unixPath: String, basePath: String): String {
         if (!SystemInfo.isWindows) return unixPath
 
-        // Try to detect distribution from executable path
-        val distribution = executablePath?.let { extractDistribution(it) }
-            ?: run {
-                // Fallback: check application settings
-                val settings = application.service<MiseApplicationSettings>()
-                val configuredPath = settings.state.executablePath
-                if (configuredPath.isNotEmpty()) {
-                    extractDistribution(configuredPath)
-                } else {
-                    null
-                }
-            }
-
+        // Detect distribution from provided path
+        val distribution = extractDistribution(basePath)
         if (distribution == null) {
             // Not in WSL context, return original path
             logger.debug("Not in WSL context, returning original path: $unixPath")
@@ -299,12 +285,13 @@ object WslPathUtils {
      * the path from a MiseDevTool object.
      *
      * @param tool The MiseDevTool containing the install path to convert
+     * @param basePath A path within the project to infer distribution from
      * @return The converted path (Windows UNC path for WSL, original path otherwise)
      * @throws IllegalStateException if WSL mode is enabled but distribution is not configured,
      *         or if the converted UNC path is not accessible
      */
-    fun convertToolPathForWsl(tool: MiseDevTool): String {
-        return convertUnixPathForWsl(tool.shimsInstallPath())
+    fun convertToolPathForWsl(tool: MiseDevTool, basePath: String): String {
+        return convertUnixPathForWsl(tool.shimsInstallPath(), basePath)
     }
 
     fun resolveUserHomeAbbreviations(

--- a/modules/products/goland/src/main/kotlin/com/github/l34130/mise/goland/go/MiseProjectGoSdkSetup.kt
+++ b/modules/products/goland/src/main/kotlin/com/github/l34130/mise/goland/go/MiseProjectGoSdkSetup.kt
@@ -3,6 +3,7 @@ package com.github.l34130.mise.goland.go
 import com.github.l34130.mise.core.command.MiseDevTool
 import com.github.l34130.mise.core.command.MiseDevToolName
 import com.github.l34130.mise.core.setup.AbstractProjectSdkSetup
+import com.github.l34130.mise.core.util.guessMiseProjectPath
 import com.github.l34130.mise.core.wsl.WslPathUtils
 import com.goide.configuration.GoSdkConfigurable
 import com.goide.sdk.GoSdk
@@ -30,7 +31,7 @@ class MiseProjectGoSdkSetup : AbstractProjectSdkSetup() {
             ReadAction.compute<GoSdk, Throwable> {
                 sdkService.getSdk(null)
             }
-        val newSdk = tool.asGoSdk()
+        val newSdk = tool.asGoSdk(project.guessMiseProjectPath())
 
         if (currentSdk == GoSdk.NULL) {
             return SdkStatus.NeedsUpdate(
@@ -62,7 +63,7 @@ class MiseProjectGoSdkSetup : AbstractProjectSdkSetup() {
         val sdkService = GoSdkService.getInstance(project)
 
         return WriteAction.computeAndWait<ApplySdkResult, Throwable> {
-            val sdk = tool.asGoSdk()
+            val sdk = tool.asGoSdk(project.guessMiseProjectPath())
             if (sdk == GoSdk.NULL) {
                 throw IllegalStateException("Failed to create Go SDK from path: ${tool.shimsInstallPath()}")
             }
@@ -78,8 +79,8 @@ class MiseProjectGoSdkSetup : AbstractProjectSdkSetup() {
     @Suppress("UNCHECKED_CAST")
     override fun <T : Configurable> getConfigurableClass(): KClass<out T> = GoSdkConfigurable::class as KClass<out T>
 
-    private fun MiseDevTool.asGoSdk(): GoSdk {
-        val basePath = WslPathUtils.convertToolPathForWsl(this)
+    private fun MiseDevTool.asGoSdk(projectPath: String): GoSdk {
+        val basePath = WslPathUtils.convertToolPathForWsl(this, projectPath)
         var sdk = GoSdk.fromHomePath(basePath)
         if (sdk == GoSdk.NULL) {
             // Go 1.25+ - try with /go subdirectory

--- a/modules/products/idea/src/main/kotlin/com/github/l34130/mise/idea/jdk/MiseProjectJdkSetup.kt
+++ b/modules/products/idea/src/main/kotlin/com/github/l34130/mise/idea/jdk/MiseProjectJdkSetup.kt
@@ -3,6 +3,7 @@ package com.github.l34130.mise.idea.jdk
 import com.github.l34130.mise.core.command.MiseDevTool
 import com.github.l34130.mise.core.command.MiseDevToolName
 import com.github.l34130.mise.core.setup.AbstractProjectSdkSetup
+import com.github.l34130.mise.core.util.guessMiseProjectPath
 import com.github.l34130.mise.core.wsl.WslPathUtils
 import com.intellij.openapi.application.WriteAction
 import com.intellij.openapi.diagnostic.logger
@@ -24,7 +25,7 @@ class MiseProjectJdkSetup : AbstractProjectSdkSetup() {
         project: Project,
     ): SdkStatus {
         val currentSdk = ProjectRootManager.getInstance(project).projectSdk
-        val newSdk = tool.asJavaSdk()
+        val newSdk = tool.asJavaSdk(project.guessMiseProjectPath())
 
         if (currentSdk == null) {
             return SdkStatus.NeedsUpdate(
@@ -76,7 +77,7 @@ class MiseProjectJdkSetup : AbstractProjectSdkSetup() {
             val projectJdkTable = ProjectJdkTable.getInstance()
 
             val sdk =
-                tool.asJavaSdk().also { sdk ->
+                tool.asJavaSdk(project.guessMiseProjectPath()).also { sdk ->
                     val oldJdk = projectJdkTable.findJdk(tool.jdkName())
                     if (oldJdk != null) {
                         projectJdkTable.updateJdk(oldJdk, sdk)
@@ -100,8 +101,8 @@ class MiseProjectJdkSetup : AbstractProjectSdkSetup() {
 
     override fun <T : Configurable> getConfigurableClass(): KClass<out T>? = null
 
-    private fun MiseDevTool.asJavaSdk(): Sdk {
-        val sdkPath = WslPathUtils.convertToolPathForWsl(this)
+    private fun MiseDevTool.asJavaSdk(projectPath: String): Sdk {
+        val sdkPath = WslPathUtils.convertToolPathForWsl(this, projectPath)
         return JavaSdk.getInstance().createJdk(this.jdkName(), sdkPath, false)
     }
 

--- a/modules/products/nodejs/src/main/kotlin/com/github/l34130/mise/nodejs/deno/MiseProjectDenoSetup.kt
+++ b/modules/products/nodejs/src/main/kotlin/com/github/l34130/mise/nodejs/deno/MiseProjectDenoSetup.kt
@@ -4,6 +4,7 @@ import com.github.l34130.mise.core.ShimUtils
 import com.github.l34130.mise.core.command.MiseDevTool
 import com.github.l34130.mise.core.command.MiseDevToolName
 import com.github.l34130.mise.core.setup.AbstractProjectSdkSetup
+import com.github.l34130.mise.core.util.guessMiseProjectPath
 import com.github.l34130.mise.core.wsl.WslPathUtils
 import com.intellij.deno.DenoConfigurable
 import com.intellij.deno.DenoSettings
@@ -27,7 +28,7 @@ class MiseProjectDenoSetup : AbstractProjectSdkSetup() {
             ReadAction.compute<String?, Throwable> {
                 settings.getDenoPath()
             }
-        val newDenoPath = tool.asDenoPath()
+        val newDenoPath = tool.asDenoPath(project.guessMiseProjectPath())
 
         return if (currentDenoPath == newDenoPath) {
             SdkStatus.UpToDate
@@ -44,7 +45,7 @@ class MiseProjectDenoSetup : AbstractProjectSdkSetup() {
         project: Project,
     ): ApplySdkResult {
         val settings = DenoSettings.getService(project)
-        val newDenoPath = tool.asDenoPath()
+        val newDenoPath = tool.asDenoPath(project.guessMiseProjectPath())
 
         return WriteAction.computeAndWait<ApplySdkResult, Throwable> {
             settings.setDenoPath(newDenoPath)
@@ -59,8 +60,8 @@ class MiseProjectDenoSetup : AbstractProjectSdkSetup() {
     @Suppress("UNCHECKED_CAST")
     override fun <T : Configurable> getConfigurableClass(): KClass<out T> = DenoConfigurable::class as KClass<out T>
 
-    private fun MiseDevTool.asDenoPath(): String {
-        val basePath = WslPathUtils.convertToolPathForWsl(this)
+    private fun MiseDevTool.asDenoPath(projectPath: String): String {
+        val basePath = WslPathUtils.convertToolPathForWsl(this, projectPath)
         return ShimUtils.findExecutable(basePath, "deno").path
     }
 

--- a/modules/products/nodejs/src/main/kotlin/com/github/l34130/mise/nodejs/node/MiseProjectInterpreterSetup.kt
+++ b/modules/products/nodejs/src/main/kotlin/com/github/l34130/mise/nodejs/node/MiseProjectInterpreterSetup.kt
@@ -3,6 +3,7 @@ package com.github.l34130.mise.nodejs.node
 import com.github.l34130.mise.core.command.MiseDevTool
 import com.github.l34130.mise.core.command.MiseDevToolName
 import com.github.l34130.mise.core.setup.AbstractProjectSdkSetup
+import com.github.l34130.mise.core.util.guessMiseProjectPath
 import com.github.l34130.mise.core.wsl.WslPathUtils
 import com.intellij.javascript.nodejs.interpreter.NodeJsInterpreter
 import com.intellij.javascript.nodejs.interpreter.NodeJsInterpreterManager
@@ -31,7 +32,7 @@ class MiseProjectInterpreterSetup : AbstractProjectSdkSetup() {
             ReadAction.compute<NodeJsInterpreter?, Throwable> {
                 nodeJsInterpreterManager.interpreter
             }
-        val newInterpreter = tool.asNodeJsLocalInterpreter()
+        val newInterpreter = tool.asNodeJsLocalInterpreter(project.guessMiseProjectPath())
 
         if (currentInterpreter == null || !currentInterpreter.deepEquals(newInterpreter)) {
             return SdkStatus.NeedsUpdate(
@@ -48,7 +49,7 @@ class MiseProjectInterpreterSetup : AbstractProjectSdkSetup() {
         project: Project,
     ): ApplySdkResult {
         val nodeJsInterpreterManager = NodeJsInterpreterManager.getInstance(project)
-        val newInterpreter = tool.asNodeJsLocalInterpreter()
+        val newInterpreter = tool.asNodeJsLocalInterpreter(project.guessMiseProjectPath())
 
         return WriteAction.computeAndWait<ApplySdkResult, Throwable> {
             nodeJsInterpreterManager.setInterpreterRef(newInterpreter.toRef())
@@ -63,8 +64,8 @@ class MiseProjectInterpreterSetup : AbstractProjectSdkSetup() {
     @Suppress("UNCHECKED_CAST")
     override fun <T : Configurable> getConfigurableClass(): KClass<out T> = NodeSettingsConfigurable::class as KClass<out T>
 
-    private fun MiseDevTool.asNodeJsLocalInterpreter(): NodeJsLocalInterpreter {
-        val basePath = WslPathUtils.convertToolPathForWsl(this)
+    private fun MiseDevTool.asNodeJsLocalInterpreter(projectPath: String): NodeJsLocalInterpreter {
+        val basePath = WslPathUtils.convertToolPathForWsl(this, projectPath)
 
         val interpreterPath =
             if (SystemInfo.isWindows) {

--- a/modules/products/nodejs/src/main/kotlin/com/github/l34130/mise/nodejs/node/MiseProjectPackageSetup.kt
+++ b/modules/products/nodejs/src/main/kotlin/com/github/l34130/mise/nodejs/node/MiseProjectPackageSetup.kt
@@ -93,7 +93,7 @@ class MiseProjectPackageSetup : AbstractProjectSdkSetup() {
 
     private fun MiseDevTool.asPackage(project: Project): NodePackage {
         val devToolName = getDevToolName(project).value
-        val basePath = WslPathUtils.convertToolPathForWsl(this)
+        val basePath = WslPathUtils.convertToolPathForWsl(this, project.guessMiseProjectPath())
         val path = ShimUtils.findExecutable(basePath, devToolName).path
         val nodePackage = NpmUtil.DESCRIPTOR.createPackage(path)
         check(nodePackage.isValid(project, null)) {

--- a/modules/products/pycharm/src/main/kotlin/com/github/l34130/mise/pycharm/sdk/MisePythonSdkSetup.kt
+++ b/modules/products/pycharm/src/main/kotlin/com/github/l34130/mise/pycharm/sdk/MisePythonSdkSetup.kt
@@ -93,7 +93,7 @@ class MisePythonSdkSetup : AbstractProjectSdkSetup() {
                 .trim()
 
         // Convert to Windows UNC path if in WSL mode using the shared utility
-        val pythonPath = WslPathUtils.convertUnixPathForWsl(pythonUnixPath)
+        val pythonPath = WslPathUtils.convertUnixPathForWsl(pythonUnixPath, project.guessMiseProjectPath())
 
         // Get Python version
         val pythonVersion =

--- a/modules/products/ruby/src/main/kotlin/com/github/l34130/mise/ruby/sdk/MiseRubyProjectSdkSetup.kt
+++ b/modules/products/ruby/src/main/kotlin/com/github/l34130/mise/ruby/sdk/MiseRubyProjectSdkSetup.kt
@@ -3,6 +3,7 @@ package com.github.l34130.mise.ruby.sdk
 import com.github.l34130.mise.core.command.MiseDevTool
 import com.github.l34130.mise.core.command.MiseDevToolName
 import com.github.l34130.mise.core.setup.AbstractProjectSdkSetup
+import com.github.l34130.mise.core.util.guessMiseProjectPath
 import com.github.l34130.mise.core.wsl.WslPathUtils
 import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.application.WriteAction
@@ -27,7 +28,7 @@ class MiseRubyProjectSdkSetup : AbstractProjectSdkSetup() {
             ReadAction.compute<Sdk?, Throwable> {
                 ProjectRootManager.getInstance(project).projectSdk
             }
-        val newSdk = tool.asRubySdk()
+        val newSdk = tool.asRubySdk(project.guessMiseProjectPath())
 
         if (currentSdk == null || currentSdk.name != newSdk.name && currentSdk.homePath != newSdk.homePath) {
             return SdkStatus.NeedsUpdate(
@@ -45,7 +46,7 @@ class MiseRubyProjectSdkSetup : AbstractProjectSdkSetup() {
     ): ApplySdkResult =
         WriteAction.computeAndWait<ApplySdkResult, Throwable> {
             val sdk =
-                tool.asRubySdk().also { sdk ->
+                tool.asRubySdk(project.guessMiseProjectPath()).also { sdk ->
                     val exists = RubySdkType.getAllValidRubySdks().firstOrNull { it.name == sdk.name }
                     if (exists == null) {
                         ProjectJdkTable.getInstance().addJdk(sdk)
@@ -66,8 +67,8 @@ class MiseRubyProjectSdkSetup : AbstractProjectSdkSetup() {
     // RubyDefaultProjectSdkGemsConfigurable::class as KClass<out T>
     override fun <T : Configurable> getConfigurableClass(): KClass<out T>? = null
 
-    private fun MiseDevTool.asRubySdk(): Sdk {
-        val sdkPath = WslPathUtils.convertToolPathForWsl(this)
+    private fun MiseDevTool.asRubySdk(projectPath: String): Sdk {
+        val sdkPath = WslPathUtils.convertToolPathForWsl(this, projectPath)
         return ProjectJdkImpl(
             "mise: ${this.shimsVersion()}",
             RubySdkType.getInstance(),


### PR DESCRIPTION
During tool checks `convertToolPathForWsl` was falling back to application settings to try to find the context for detection of WSLDistribution, but this is unreliable if a user has not explicitly set a path for the mise executable & even if they have, there is also a project level override which was being ignored.

Options were to explicitly pass down the project, or a path that could be used. Rather than tie this method to the project I opted for a path string.  

The manifestation of this was notifications like "C:\users\username\.local\share\mise\installs\java\21 doesn't exist" on start up of a WSL project. Showing that it was looking in the wrong place. 