### PR TITLE
Don't bundle kotlin-stdlib with the plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,9 @@ kotlin {
 // Dependencies are managed with Gradle version catalog - read more: https://docs.gradle.org/current/userguide/platforms.html#sub:version-catalog
 dependencies {
     testImplementation(libs.junit)
-    implementation(libs.jackson.module.kotlin)
+    implementation(libs.jackson.module.kotlin) {
+        exclude(group = "org.jetbrains.kotlin")
+    }
 
 
 


### PR DESCRIPTION
If a bundled kotlin-stdlib does not match the version of Kotlin shipped with the IDE then ClassLoaderExceptions can happen.

It would have been better to unbundle Jackson (and thus also kotlin-stdlib), but there was a note in the Mise files that it's not possible with 2025.1.
The other, less optimal, solution is to keep Jackson but exclude kotlin-stdlib from the mise.zip. 

In theory, it's possible that Jackson throws exceptions if its use of the older kotlin-stdlib doesn't the newer kotlin-stdlib at runtime. But backwards compatibility of kotlin-stdlib (running with 2.x, building against 1.9.x for example) is much better than the other direction.

For example, I got this exception when I wanted to create an extension for BashSupport Pro.
This happened because the Mise extension (which has the Mise plugin and its dependencies in the classpath) first uses Kotlin classes (which make the classloader load from kotlin-stdlib bundled with Mise) and then execution proceeds and BashSupport Pro's classes (which were built against Kotlin of the IDE) don't match the older kotlin-stdlib of the Mise plugin.

```text
java.lang.LinkageError: loader constraint violation: when resolving method 'kotlin.text.MatchGroup kotlin.text.jdk8.RegexExtensionsJDK8Kt.get(kotlin.text.MatchGroupCollection, java.lang.String)' the class loader com.intellij.ide.plugins.cl.PluginClassLoader @e24cf86 of the current class, pro/bashsupport/shell/debug/shellDebugger/BashdbCustomization, and the class loader com.intellij.util.lang.PathClassLoader @4f3f5b24 for the method's defining class, kotlin/text/jdk8/RegexExtensionsJDK8Kt, have different Class objects for the type kotlin/text/MatchGroupCollection used in the signature (pro.bashsupport.shell.debug.shellDebugger.BashdbCustomization is in unnamed module of loader com.intellij.ide.plugins.cl.PluginClassLoader @e24cf86, parent loader 'bootstrap'; kotlin.text.jdk8.RegexExtensionsJDK8Kt is in unnamed module of loader com.intellij.util.lang.PathClassLoader @4f3f5b24)
	at pro.bashsupport.shell.debug.shellDebugger.BashdbCustomization.extractSourcePosition(BashdbCustomization.kt:34)
	at pro.bashsupport.shell.debug.shellDebugger.commands.UtilsKt.findLastSourcePosition$lambda$3(utils.kt:24)
	at pro.bashsupport.shell.debug.shellDebugger.commands.UtilsKt.debuggerOutputLastMatchingLine$lambda$2(utils.kt:18)
	at kotlin.sequences.TransformingSequence$iterator$1.next(Sequences.kt:210)
	at kotlin.sequences.FilteringSequence$iterator$1.calcNext(Sequences.kt:170)
	at kotlin.sequences.FilteringSequence$iterator$1.hasNext(Sequences.kt:194)
	at kotlin.sequences.SequencesKt___SequencesKt.firstOrNull(_Sequences.kt:168)
	at pro.bashsupport.shell.debug.shellDebugger.commands.UtilsKt.debuggerOutputLastMatchingLine(utils.kt:19)
	at pro.bashsupport.shell.debug.shellDebugger.commands.UtilsKt.findLastSourcePosition(utils.kt:23)
	at pro.bashsupport.shell.debug.shellDebugger.commands.AwaitReadyCommand$doExecute$2.invokeSuspend(AwaitReadyCommand.kt:25)
	at _COROUTINE._BOUNDARY._(CoroutineDebugging.kt:42)
	at kotlinx.coroutines.TimeoutKt.withTimeoutOrNull(Timeout.kt:101)
Caused by: java.lang.LinkageError: loader constraint violation: when resolving method 'kotlin.text.MatchGroup kotlin.text.jdk8.RegexExtensionsJDK8Kt.get(kotlin.text.MatchGroupCollection, java.lang.String)' the class loader com.intellij.ide.plugins.cl.PluginClassLoader @e24cf86 of the current class, pro/bashsupport/shell/debug/shellDebugger/BashdbCustomization, and the class loader com.intellij.util.lang.PathClassLoader @4f3f5b24 for the method's defining class, kotlin/text/jdk8/RegexExtensionsJDK8Kt, have different Class objects for the type kotlin/text/MatchGroupCollection used in the signature (pro.bashsupport.shell.debug.shellDebugger.BashdbCustomization is in unnamed module of loader com.intellij.ide.plugins.cl.PluginClassLoader @e24cf86, parent loader 'bootstrap'; kotlin.text.jdk8.RegexExtensionsJDK8Kt is in unnamed module of loader com.intellij.util.lang.PathClassLoader @4f3f5b24)
	at pro.bashsupport.shell.debug.shellDebugger.BashdbCustomization.extractSourcePosition(BashdbCustomization.kt:34)
	at pro.bashsupport.shell.debug.shellDebugger.commands.UtilsKt.findLastSourcePosition$lambda$3(utils.kt:24)
	at pro.bashsupport.shell.debug.shellDebugger.commands.UtilsKt.debuggerOutputLastMatchingLine$lambda$2(utils.kt:18)
	at kotlin.sequences.TransformingSequence$iterator$1.next(Sequences.kt:210)
	at kotlin.sequences.FilteringSequence$iterator$1.calcNext(Sequences.kt:170)
	at kotlin.sequences.FilteringSequence$iterator$1.hasNext(Sequences.kt:194)
	at kotlin.sequences.SequencesKt___SequencesKt.firstOrNull(_Sequences.kt:168)
	at pro.bashsupport.shell.debug.shellDebugger.commands.UtilsKt.debuggerOutputLastMatchingLine(utils.kt:19)
	at pro.bashsupport.shell.debug.shellDebugger.commands.UtilsKt.findLastSourcePosition(utils.kt:23)
	at pro.bashsupport.shell.debug.shellDebugger.commands.AwaitReadyCommand$doExecute$2.invokeSuspend(AwaitReadyCommand.kt:25)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith$$$capture(ContinuationImpl.kt:33)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt)
	at --- Async.Stack.Trace --- (captured by IntelliJ IDEA debugger)
	at kotlinx.coroutines.debug.internal.DebugProbesImpl$CoroutineOwner.<init>(DebugProbesImpl.kt:531)
	at kotlinx.coroutines.debug.internal.DebugProbesImpl.createOwner(DebugProbesImpl.kt:510)
	at kotlinx.coroutines.debug.internal.DebugProbesImpl.probeCoroutineCreated$kotlinx_coroutines_core(DebugProbesImpl.kt:497)
	at kotlin.coroutines.jvm.internal.DebugProbesKt.probeCoroutineCreated(DebugProbes.kt:7)
	at kotlin.coroutines.intrinsics.IntrinsicsKt__IntrinsicsJvmKt.createCoroutineUnintercepted(IntrinsicsJvm.kt:161)
	at kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable(Cancellable.kt:26)
	at kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable$default(Cancellable.kt:21)
	at kotlinx.coroutines.CoroutineStart.invoke(CoroutineStart.kt:88)
	at kotlinx.coroutines.AbstractCoroutine.start(AbstractCoroutine.kt:123)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking$BuildersKt__BuildersKt(Builders.kt:84)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking(Builders.kt:53)
	at kotlinx.coroutines.BuildersKt.runBlocking(Unknown Source)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking$default(Builders.kt:49)
	at kotlinx.coroutines.BuildersKt.runBlocking$default(Unknown Source)
	at pro.bashsupport.shell.debug.xdebugger.ShellDebugProcess$sessionInitialized$1.run(ShellDebugProcess.kt:118)
	at com.intellij.openapi.progress.impl.CoreProgressManager.startTask(CoreProgressManager.java:497)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.startTask(ProgressManagerImpl.java:118)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcessWithProgressAsynchronously$7(CoreProgressManager.java:548)
	at com.intellij.openapi.progress.impl.ProgressRunner.lambda$submit$4(ProgressRunner.java:252)
	at com.intellij.openapi.progress.ProgressManager.lambda$runProcess$0(ProgressManager.java:98)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcess$1(CoreProgressManager.java:229)
	at com.intellij.platform.diagnostic.telemetry.helpers.TraceKt.use(trace.kt:43)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcess$2(CoreProgressManager.java:228)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$executeProcessUnderProgress$14(CoreProgressManager.java:680)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:755)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computeUnderProgress(CoreProgressManager.java:711)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:679)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:77)
	at com.intellij.openapi.progress.impl.CoreProgressManager.runProcess(CoreProgressManager.java:209)
	at com.intellij.openapi.progress.ProgressManager.runProcess(ProgressManager.java:98)
	at com.intellij.openapi.progress.impl.ProgressRunner.lambda$submit$5(ProgressRunner.java:252)
	at com.intellij.openapi.progress.impl.ProgressRunner$ProgressRunnable.run$$$capture(ProgressRunner.java:513)
	at com.intellij.openapi.progress.impl.ProgressRunner$ProgressRunnable.run(ProgressRunner.java)
	at --- Async.Stack.Trace --- (captured by IntelliJ IDEA debugger)
	at com.intellij.openapi.progress.impl.ProgressRunner$ProgressRunnable.<init>(ProgressRunner.java:503)
	at com.intellij.openapi.progress.impl.ProgressRunner.lambda$launchTask$20(ProgressRunner.java:471)
	at java.base/java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:863)
	at java.base/java.util.concurrent.CompletableFuture.uniWhenCompleteStage(CompletableFuture.java:887)
	at java.base/java.util.concurrent.CompletableFuture.whenComplete(CompletableFuture.java:2357)
	at com.intellij.openapi.progress.impl.ProgressRunner.launchTask(ProgressRunner.java:466)
	at com.intellij.openapi.progress.impl.ProgressRunner.execFromEDT(ProgressRunner.java:307)
	at com.intellij.openapi.progress.impl.ProgressRunner.submit(ProgressRunner.java:255)
	at com.intellij.openapi.progress.impl.CoreProgressManager.runProcessWithProgressAsynchronously(CoreProgressManager.java:556)
	at com.intellij.openapi.progress.impl.CoreProgressManager.runProcessWithProgressAsynchronously(CoreProgressManager.java:490)
	at com.intellij.openapi.progress.impl.CoreProgressManager.runProcessWithProgressAsynchronously(CoreProgressManager.java:482)
	at com.intellij.openapi.progress.impl.CoreProgressManager.runAsynchronously(CoreProgressManager.java:459)
	at com.intellij.openapi.progress.impl.CoreProgressManager.run(CoreProgressManager.java:442)
	at pro.bashsupport.shell.debug.xdebugger.ShellDebugProcess.sessionInitialized(ShellDebugProcess.kt:113)
	at com.intellij.xdebugger.impl.XDebugSessionImpl.initSessionTab(XDebugSessionImpl.java:397)
	at com.intellij.xdebugger.impl.XDebugSessionImpl.init(XDebugSessionImpl.java:344)
	at com.intellij.xdebugger.impl.XDebuggerManagerImpl.startSession(XDebuggerManagerImpl.java:295)
	at com.intellij.xdebugger.impl.XDebuggerManagerImpl.startSession(XDebuggerManagerImpl.java:235)
	at pro.bashsupport.compatibility.Xdebugmanager_compatKt.launchNewSessionCompatibility(xdebugmanager_compat.kt:9)
	at pro.bashsupport.shell.debug.xdebugger.ShellDebugProgramRunner.finishOnDispatchThread(ShellDebugProgramRunner.kt:147)
	at pro.bashsupport.shell.debug.xdebugger.ShellDebugProgramRunner.finishOnDispatchThread(ShellDebugProgramRunner.kt:62)
	at pro.bashsupport.shell.runConfig.MacroAwareAsyncProgramRunner.prepareAndExecute$lambda$9$lambda$8$lambda$7(MacroAwareAsyncProgramRunner.kt:74)
	at pro.bashsupport.util.ThreadingContextKt.withExecutionEnvironmentContextAsyncPromise(threadingContext.kt:27)
	at pro.bashsupport.shell.runConfig.MacroAwareAsyncProgramRunner.prepareAndExecute$lambda$9$lambda$8(MacroAwareAsyncProgramRunner.kt:73)
	at pro.bashsupport.util.EdtUtilKt.runInEdtAndGet$lambda$1(edtUtil.kt:39)
	at pro.bashsupport.util.EdtUtilKt.runInEdtAndWait$lambda$0(edtUtil.kt:23)
	at com.intellij.openapi.application.TransactionGuardImpl.runWithWritingAllowed(TransactionGuardImpl.java:240)
	at com.intellij.openapi.application.TransactionGuardImpl.access$100(TransactionGuardImpl.java:25)
	at com.intellij.openapi.application.TransactionGuardImpl$1.run(TransactionGuardImpl.java:202)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runIntendedWriteActionOnCurrentThread$lambda$7(AnyThreadWriteThreadingSupport.kt:319)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWriteIntentReadAction$lambda$6(AnyThreadWriteThreadingSupport.kt:274)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWithTemporaryThreadLocal(AnyThreadWriteThreadingSupport.kt:204)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWriteIntentReadAction(AnyThreadWriteThreadingSupport.kt:274)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWriteIntentReadAction(AnyThreadWriteThreadingSupport.kt:222)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runIntendedWriteActionOnCurrentThread(AnyThreadWriteThreadingSupport.kt:318)
	at com.intellij.openapi.application.impl.ApplicationImpl.runIntendedWriteActionOnCurrentThread(ApplicationImpl.java:928)
	at com.intellij.openapi.application.impl.ApplicationImpl$4.run(ApplicationImpl.java:501)
	at com.intellij.openapi.application.impl.AppImplKt.rethrowExceptions$lambda$2(appImpl.kt:66)
	at com.intellij.util.concurrency.ChildContext$runInChildContext$1.invoke(propagation.kt:102)
	at com.intellij.util.concurrency.ChildContext$runInChildContext$1.invoke(propagation.kt:102)
	at com.intellij.util.concurrency.ChildContext.runInChildContext(propagation.kt:108)
	at com.intellij.util.concurrency.ChildContext.runInChildContext(propagation.kt:102)
	at com.intellij.util.concurrency.ContextRunnable.run$$$capture(ContextRunnable.java:27)
	at com.intellij.util.concurrency.ContextRunnable.run(ContextRunnable.java)
	at --- Async.Stack.Trace --- (captured by IntelliJ IDEA debugger)
	at com.intellij.util.concurrency.ContextRunnable.<init>(ContextRunnable.java:15)
	at com.intellij.util.concurrency.Propagation.capturePropagationContext(propagation.kt:372)
	at com.intellij.util.concurrency.AppScheduledExecutorService.captureContextCancellationForRunnableThatDoesNotOutliveContextScope(AppScheduledExecutorService.java:243)
	at com.intellij.openapi.application.impl.AppImplKt.rethrowExceptions(appImpl.kt:64)
	at com.intellij.openapi.application.impl.ApplicationImpl.invokeAndWait(ApplicationImpl.java:489)
	at com.intellij.openapi.application.impl.ApplicationImpl.invokeAndWait(ApplicationImpl.java:526)
	at pro.bashsupport.util.EdtUtilKt.runInEdtAndWait(edtUtil.kt:29)
	at pro.bashsupport.util.EdtUtilKt.runInEdtAndGet(edtUtil.kt:38)
	at pro.bashsupport.shell.runConfig.MacroAwareAsyncProgramRunner.prepareAndExecute$lambda$9(MacroAwareAsyncProgramRunner.kt:72)
	at pro.bashsupport.shell.runConfig.MacroAwareAsyncProgramRunner.prepareAndExecute$lambda$10(MacroAwareAsyncProgramRunner.kt:71)
	at org.jetbrains.concurrency.AsyncPromise.then$lambda$12$lambda$10(AsyncPromise.kt:154)
	at org.jetbrains.concurrency.AsyncPromise.then$lambda$12$lambda$11(AsyncPromise.kt:152)
	at java.base/java.util.concurrent.CompletableFuture$UniApply.tryFire$$$capture(CompletableFuture.java:646)
	at java.base/java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java)
	at --- Async.Stack.Trace --- (captured by IntelliJ IDEA debugger)
	at java.base/java.util.concurrent.CompletableFuture$UniApply.<init>(CompletableFuture.java:625)
	at java.base/java.util.concurrent.CompletableFuture.uniApplyStage(CompletableFuture.java:664)
	at java.base/java.util.concurrent.CompletableFuture.thenApply(CompletableFuture.java:2200)
	at org.jetbrains.concurrency.AsyncPromise.then$lambda$12(AsyncPromise.kt:152)
	at org.jetbrains.concurrency.AsyncPromise.wrapWithCancellationPropagation(AsyncPromise.kt:163)
	at org.jetbrains.concurrency.AsyncPromise.then(AsyncPromise.kt:151)
	at pro.bashsupport.shell.runConfig.MacroAwareAsyncProgramRunner.prepareAndExecute(MacroAwareAsyncProgramRunner.kt:71)
	at pro.bashsupport.shell.runConfig.MacroAwareAsyncProgramRunner.execute(MacroAwareAsyncProgramRunner.kt:38)
	at com.intellij.execution.runners.AsyncProgramRunner.execute$lambda$0(GenericProgramRunner.kt:53)
	at com.intellij.execution.impl.ExecutionManagerImpl.startRunProfile$lambda$5(ExecutionManagerImpl.kt:228)
	at com.intellij.execution.impl.ExecutionManagerImpl$doStartRunProfile$$inlined$Runnable$1.run(Runnable.kt:30)
	at com.intellij.openapi.application.TransactionGuardImpl.runWithWritingAllowed(TransactionGuardImpl.java:240)
	at com.intellij.openapi.application.TransactionGuardImpl.access$100(TransactionGuardImpl.java:25)
	at com.intellij.openapi.application.TransactionGuardImpl$1.run(TransactionGuardImpl.java:202)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runIntendedWriteActionOnCurrentThread$lambda$7(AnyThreadWriteThreadingSupport.kt:319)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWriteIntentReadAction$lambda$6(AnyThreadWriteThreadingSupport.kt:274)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWithTemporaryThreadLocal(AnyThreadWriteThreadingSupport.kt:204)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWriteIntentReadAction(AnyThreadWriteThreadingSupport.kt:274)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWriteIntentReadAction(AnyThreadWriteThreadingSupport.kt:222)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runIntendedWriteActionOnCurrentThread(AnyThreadWriteThreadingSupport.kt:318)
	at com.intellij.openapi.application.impl.ApplicationImpl.runIntendedWriteActionOnCurrentThread(ApplicationImpl.java:928)
	at com.intellij.openapi.application.impl.ApplicationImpl$4.run(ApplicationImpl.java:501)
	at com.intellij.util.concurrency.ChildContext$runInChildContext$1.invoke(propagation.kt:102)
	at com.intellij.util.concurrency.ChildContext$runInChildContext$1.invoke(propagation.kt:102)
	at com.intellij.util.concurrency.ChildContext.runInChildContext(propagation.kt:108)
	at com.intellij.util.concurrency.ChildContext.runInChildContext(propagation.kt:102)
	at com.intellij.util.concurrency.ContextRunnable.run$$$capture(ContextRunnable.java:27)
	at com.intellij.util.concurrency.ContextRunnable.run(ContextRunnable.java)
	at --- Async.Stack.Trace --- (captured by IntelliJ IDEA debugger)
	at com.intellij.util.concurrency.ContextRunnable.<init>(ContextRunnable.java:15)
	at com.intellij.util.concurrency.Propagation.capturePropagationContext(propagation.kt:384)
	at com.intellij.openapi.application.impl.ApplicationImpl.invokeLater(ApplicationImpl.java:356)
	at com.intellij.openapi.application.impl.ApplicationImpl.invokeLater(ApplicationImpl.java:338)
	at com.intellij.execution.impl.ExecutionManagerImpl$doStartRunProfile$$inlined$Runnable$2.run(Runnable.kt:15)
	at com.intellij.execution.impl.ExecutionManagerImpl.compileAndRun(ExecutionManagerImpl.kt:409)
	at com.intellij.execution.impl.ExecutionManagerImpl.doStartRunProfile(ExecutionManagerImpl.kt:352)
	at com.intellij.execution.impl.ExecutionManagerImpl.startRunProfile(ExecutionManagerImpl.kt:225)
	at com.intellij.execution.runners.AsyncProgramRunner.execute(GenericProgramRunner.kt:52)
	at com.intellij.execution.impl.ExecutionManagerImpl.executeConfiguration(ExecutionManagerImpl.kt:831)
	at com.intellij.execution.impl.ExecutionManagerImpl.executeConfiguration$lambda$21$lambda$19(ExecutionManagerImpl.kt:764)
	at com.intellij.execution.impl.ExecutionManagerImpl.executeConfiguration$lambda$21$lambda$20(ExecutionManagerImpl.kt:760)
	at com.intellij.openapi.application.impl.NonBlockingReadActionImpl$Submission.lambda$safeTransferToEdt$6(NonBlockingReadActionImpl.java:735)
	at com.intellij.openapi.application.TransactionGuardImpl.runWithWritingAllowed(TransactionGuardImpl.java:240)
	at com.intellij.openapi.application.TransactionGuardImpl.access$100(TransactionGuardImpl.java:25)
	at com.intellij.openapi.application.TransactionGuardImpl$1.run(TransactionGuardImpl.java:202)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runIntendedWriteActionOnCurrentThread$lambda$7(AnyThreadWriteThreadingSupport.kt:319)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWriteIntentReadAction$lambda$6(AnyThreadWriteThreadingSupport.kt:274)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWithTemporaryThreadLocal(AnyThreadWriteThreadingSupport.kt:204)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWriteIntentReadAction(AnyThreadWriteThreadingSupport.kt:274)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWriteIntentReadAction(AnyThreadWriteThreadingSupport.kt:222)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runIntendedWriteActionOnCurrentThread(AnyThreadWriteThreadingSupport.kt:318)
	at com.intellij.openapi.application.impl.ApplicationImpl.runIntendedWriteActionOnCurrentThread(ApplicationImpl.java:928)
	at com.intellij.openapi.application.impl.ApplicationImpl$5.run(ApplicationImpl.java:514)
	at com.intellij.openapi.application.impl.FlushQueue.runNextEvent(FlushQueue.java:117)
	at com.intellij.openapi.application.impl.FlushQueue.flushNow(FlushQueue.java:43)
	at java.desktop/java.awt.event.InvocationEvent.dispatch$$$capture(InvocationEvent.java:318)
	at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java)
	at --- Async.Stack.Trace --- (captured by IntelliJ IDEA debugger)
	at java.desktop/java.awt.event.InvocationEvent.<init>(InvocationEvent.java:291)
	at java.desktop/java.awt.event.InvocationEvent.<init>(InvocationEvent.java:177)
	at java.desktop/java.awt.EventQueue.invokeLater(EventQueue.java:1327)
	at java.desktop/javax.swing.SwingUtilities.invokeLater(SwingUtilities.java:1421)
	at com.intellij.openapi.application.impl.FlushQueue.requestFlush(FlushQueue.java:194)
	at com.intellij.openapi.application.impl.FlushQueue.push(FlushQueue.java:65)
	at com.intellij.openapi.application.impl.LaterInvocator.invokeLater(LaterInvocator.java:87)
	at com.intellij.openapi.application.impl.ApplicationImpl.invokeLater(ApplicationImpl.java:360)
	at com.intellij.openapi.application.impl.NonBlockingReadActionImpl$Submission.safeTransferToEdt(NonBlockingReadActionImpl.java:718)
	at com.intellij.openapi.application.impl.NonBlockingReadActionImpl$Submission.insideReadAction(NonBlockingReadActionImpl.java:622)
	at com.intellij.openapi.application.impl.NonBlockingReadActionImpl$Submission.lambda$attemptComputation$3(NonBlockingReadActionImpl.java:582)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.tryRunReadAction$lambda$11(AnyThreadWriteThreadingSupport.kt:522)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWithTemporaryThreadLocal(AnyThreadWriteThreadingSupport.kt:204)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.tryRunReadAction(AnyThreadWriteThreadingSupport.kt:522)
	at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1064)
	at com.intellij.openapi.progress.util.ProgressIndicatorUtils.lambda$runInReadActionWithWriteActionPriority$0(ProgressIndicatorUtils.java:95)
	at com.intellij.openapi.progress.util.ProgressIndicatorUtilService.runActionAndCancelBeforeWrite(ProgressIndicatorUtilService.java:73)
	at com.intellij.openapi.progress.util.ProgressIndicatorUtils.runActionAndCancelBeforeWrite(ProgressIndicatorUtils.java:152)
	at com.intellij.openapi.progress.util.ProgressIndicatorUtils.lambda$runWithWriteActionPriority$1(ProgressIndicatorUtils.java:140)
	at com.intellij.openapi.progress.ProgressManager.lambda$runProcess$0(ProgressManager.java:98)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcess$1(CoreProgressManager.java:229)
	at com.intellij.platform.diagnostic.telemetry.helpers.TraceKt.use(trace.kt:43)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcess$2(CoreProgressManager.java:228)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$executeProcessUnderProgress$14(CoreProgressManager.java:680)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:755)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computeUnderProgress(CoreProgressManager.java:711)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:679)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:77)
	at com.intellij.openapi.progress.impl.CoreProgressManager.runProcess(CoreProgressManager.java:209)
	at com.intellij.openapi.progress.ProgressManager.runProcess(ProgressManager.java:98)
	at com.intellij.openapi.progress.util.ProgressIndicatorUtils.runWithWriteActionPriority(ProgressIndicatorUtils.java:137)
	at com.intellij.openapi.progress.util.ProgressIndicatorUtils.runInReadActionWithWriteActionPriority(ProgressIndicatorUtils.java:95)
	at com.intellij.openapi.application.impl.NonBlockingReadActionImpl$Submission.attemptComputation(NonBlockingReadActionImpl.java:582)
	at com.intellij.openapi.application.impl.NonBlockingReadActionImpl$Submission.lambda$transferToBgThread$1(NonBlockingReadActionImpl.java:481)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:735)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:732)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:400)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1.run(Executors.java:732)
	at java.base/java.lang.Thread.run(Thread.java:1583)

```