### PR TITLE
fix(pycharm): accept string values for `python.uv_venv_auto` (#471)

### DIFF
--- a/modules/products/pycharm/src/main/kotlin/com/github/l34130/mise/pycharm/sdk/MisePythonSdkSetup.kt
+++ b/modules/products/pycharm/src/main/kotlin/com/github/l34130/mise/pycharm/sdk/MisePythonSdkSetup.kt
@@ -63,16 +63,22 @@ class MisePythonSdkSetup : AbstractProjectSdkSetup() {
 
     private fun checkUvEnabled(project: Project) {
         val configEnvironment = project.service<MiseProjectSettings>().state.miseConfigEnvironment
-        val useUv =
-            // Check if the 'settings.python.uv_venv_auto' is set to true
+        val rawValue =
             MiseCommandLineHelper
                 .getConfig(project, project.guessMiseProjectPath(), configEnvironment, "settings.python.uv_venv_auto")
                 .getOrNull()
                 ?.trim()
-                ?.toBoolean() ?: false
+                ?.lowercase()
+
+        // Mise accepts true / source / create|source in addition to false (#471).
+        // Treat any non-empty, non-"false" value as enabled — Mise handles the variant semantics.
+        val useUv = !rawValue.isNullOrEmpty() && rawValue != "false"
 
         if (!useUv) {
-            throw UnsupportedOperationException("Mise Python SDK setup requires 'settings.python.uv_venv_auto' to be true.")
+            throw UnsupportedOperationException(
+                "Mise Python SDK setup requires 'settings.python.uv_venv_auto' to be enabled " +
+                    "(one of: true, source, create|source).",
+            )
         }
     }
 


### PR DESCRIPTION
## Summary
- Mise accepts string values like `source` and `create|source` for `settings.python.uv_venv_auto` in addition to booleans, but `MisePythonSdkSetup.checkUvEnabled` parsed the value via `.toBoolean()`, which collapsed those strings to `false` and disabled the UV SDK integration.
- Replaced the parser so any non-empty, non-`"false"` value is treated as enabled. All accepted variants now register the UV SDK, and the variant semantics are delegated to the Mise CLI.
- Updated the exception message to list the accepted values (`true`, `source`, `create|source`).

Fixes #471

## Test plan
- [x] `./gradlew :mise-products-pycharm:compileKotlin` passes
- [ ] In `mise.toml` under `[settings.python]`, set `uv_venv_auto` to each value below and launch the Sandbox IDE to confirm `uv (python)` is wired up as the Project SDK:
    - [ ] `true` (regression)
    - [ ] `"source"`
    - [ ] `"create|source"`
    - [ ] `false` → skipped via exception
    - [ ] unset → skipped the same way

🤖 Generated with [Claude Code](https://claude.com/claude-code)