### PR TITLE
Replace Jackson with kotlinx.serialization

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,14 +25,24 @@ kotlin {
     jvmToolchain(21)
 }
 
+// The IntelliJ Platform bundles kotlin-stdlib; bundling another copy in the plugin ZIP
+// causes LinkageError / loader constraint violations when sharing the classloader
+// with other plugins (see PR #475).
+listOf(
+    configurations.runtimeClasspath,
+    configurations.testRuntimeClasspath,
+).forEach { cfg ->
+    cfg.configure {
+        exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib")
+        exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-jdk7")
+        exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-jdk8")
+        exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-common")
+    }
+}
+
 // Dependencies are managed with Gradle version catalog - read more: https://docs.gradle.org/current/userguide/platforms.html#sub:version-catalog
 dependencies {
     testImplementation(libs.junit)
-    implementation(libs.jackson.module.kotlin) {
-        exclude(group = "org.jetbrains.kotlin")
-    }
-
-
 
     intellijPlatform {
         create(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 # libraries
 junit = "4.13.2"
+kotlinxSerialization = "1.9.0"
 
 # plugins
 changelog = "2.5.0"
@@ -9,16 +10,16 @@ kotlin = "2.2.21"
 kover = "0.9.7"
 qodana = "2025.2.4"
 detekt = "1.23.7"
-jackson = "2.17.2"  # Matches IntelliJ Platform 2025.1's version. Seems to resolve a conflict caused by 2025.1 shipping jackson-core-2.17.0 with jackson-module-kotlin-2.17.2. Can probably be removed when the plugin moves on from 2025.1 and we can just depend on the bundled version again.
 
 [libraries]
 junit = { group = "junit", name = "junit", version.ref = "junit" }
-jackson-module-kotlin = { group = "com.fasterxml.jackson.module", name = "jackson-module-kotlin", version.ref = "jackson"}
+kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
 
 [plugins]
 changelog = { id = "org.jetbrains.changelog", version.ref = "changelog" }
 gradleIdeaExt = { id = "org.jetbrains.gradle.plugin.idea-ext", version.ref = "gradleIdeaExt" }
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 qodana = { id = "org.jetbrains.qodana", version.ref = "qodana" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }

--- a/modules/core/build.gradle.kts
+++ b/modules/core/build.gradle.kts
@@ -6,10 +6,12 @@ fun properties(key: String) = project.findProperty(key).toString()
 plugins {
     id("org.jetbrains.intellij.platform.module")
     alias(libs.plugins.kotlin) // Kotlin support
+    alias(libs.plugins.kotlinSerialization)
 }
 
 dependencies {
     testImplementation(libs.junit)
+    implementation(libs.kotlinx.serialization.json)
 
     intellijPlatform {
         create(

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/command/MiseCommandLine.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/command/MiseCommandLine.kt
@@ -1,6 +1,5 @@
 package com.github.l34130.mise.core.command
 
-import com.fasterxml.jackson.core.type.TypeReference
 import com.github.l34130.mise.core.command.MiseCommandLineHelper.environmentSkipCustomization
 import com.github.l34130.mise.core.command.MiseEnvCacheKeyService.Companion.MISE_ENV_CACHE_KEY
 import com.github.l34130.mise.core.util.guessMiseProjectPath
@@ -31,24 +30,14 @@ internal class MiseCommandLine(
         params: List<String>,
         noinline parser: ((String) -> T)? = null,
     ): Result<T> {
-        val typeReference = object : TypeReference<T>() {}
-        return runCommandLine(params, typeReference, parser)
-    }
-
-    @RequiresBackgroundThread
-    inline fun <reified T> runCommandLine(
-        params: List<String>,
-        typeReference: TypeReference<T>,
-        noinline parser: ((String) -> T)? = null,
-    ): Result<T> {
         val rawResult = runRawCommandLine(params)
         return rawResult.fold(
             onSuccess = { output ->
                 if (T::class == Unit::class) {
+                    @Suppress("UNCHECKED_CAST")
                     Result.success(Unit as T)
                 } else {
-                    val parsed = parser?.invoke(output)
-                        ?: MiseCommandLineOutputParser.parse(output, typeReference)
+                    val parsed = parser?.invoke(output) ?: MiseCommandLineOutputParser.parse<T>(output)
                     Result.success(parsed)
                 }
             },

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/command/MiseCommandLineOutputParser.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/command/MiseCommandLineOutputParser.kt
@@ -1,25 +1,21 @@
 package com.github.l34130.mise.core.command
 
-import com.fasterxml.jackson.core.type.TypeReference
-import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.databind.PropertyNamingStrategies
-import com.fasterxml.jackson.module.kotlin.jacksonTypeRef
-import com.fasterxml.jackson.module.kotlin.jsonMapper
-import com.fasterxml.jackson.module.kotlin.kotlinModule
+import kotlinx.serialization.DeserializationStrategy
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNamingStrategy
+import kotlinx.serialization.serializer
 
 object MiseCommandLineOutputParser {
-    inline fun <reified T> parse(output: String): T = parse(output, jacksonTypeRef<T>())
+    inline fun <reified T> parse(output: String): T = JSON.decodeFromString(serializer<T>(), output)
 
-    fun <T> parse(
-        output: String,
-        typeReference: TypeReference<T>,
-    ): T = OBJECT_MAPPER.readValue(output, typeReference)
+    fun <T> parse(output: String, deserializer: DeserializationStrategy<T>): T =
+        JSON.decodeFromString(deserializer, output)
 
-    private val OBJECT_MAPPER =
-        jsonMapper {
-            addModule(kotlinModule())
-            configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true)
-            configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-            propertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
-        }
+    @OptIn(ExperimentalSerializationApi::class)
+    val JSON = Json {
+        ignoreUnknownKeys = true
+        namingStrategy = JsonNamingStrategy.SnakeCase
+        coerceInputValues = true
+    }
 }

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/command/MiseDevTool.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/command/MiseDevTool.kt
@@ -1,15 +1,22 @@
 package com.github.l34130.mise.core.command
 
 import com.github.l34130.mise.core.wsl.WslPathUtils
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 
+@Serializable
 data class MiseDevTool(
     val version: String,
+    @SerialName("requested_version")
     val requestedVersion: String? = null,
+    @SerialName("install_path")
     val installPath: String,
     val installed: Boolean,
     val active: Boolean,
     val source: MiseSource? = null,
-    val wslDistributionMsId: String? = null
+    @Transient
+    val wslDistributionMsId: String? = null,
 ) {
     val resolvedVersion: String
         get() = version.takeIf { it.isNotBlank() } ?: requestedVersion?.takeIf { it.isNotBlank() }.orEmpty()

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/command/MiseEnv.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/command/MiseEnv.kt
@@ -1,5 +1,8 @@
 package com.github.l34130.mise.core.command
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class MiseEnv(
     val value: String,
     val source: String? = null,

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/command/MiseEnvExtended.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/command/MiseEnvExtended.kt
@@ -1,5 +1,8 @@
 package com.github.l34130.mise.core.command
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class MiseEnvExtended(
     val value: String,
     val source: String? = null,

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/command/MiseSource.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/command/MiseSource.kt
@@ -1,10 +1,12 @@
 package com.github.l34130.mise.core.command
 
-import com.fasterxml.jackson.annotation.JsonProperty
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
+@Serializable
 data class MiseSource(
-    @field:JsonProperty("type")
+    @SerialName("type")
     val fileName: String, // .mise.toml, .mise.config, etc.
-    @field:JsonProperty("path")
+    @SerialName("path")
     val absolutePath: String, // absolute path to the source file
 )

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/command/MiseTask.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/command/MiseTask.kt
@@ -1,13 +1,23 @@
 package com.github.l34130.mise.core.command
 
+import com.github.l34130.mise.core.command.serializers.FlexibleStringListSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class MiseTask(
     val name: String,
     val aliases: List<String>? = null,
+    @Serializable(with = FlexibleStringListSerializer::class)
     val depends: List<List<String>>? = null,
+    @SerialName("wait_for")
+    @Serializable(with = FlexibleStringListSerializer::class)
     val waitFor: List<List<String>>? = null,
+    @SerialName("depends_post")
+    @Serializable(with = FlexibleStringListSerializer::class)
     val dependsPost: List<List<String>>? = null,
     val description: String? = null,
     val hide: Boolean = false,
     val source: String,
-    val command: String?,
+    val command: String? = null,
 )

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/command/serializers/FlexibleStringListSerializer.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/command/serializers/FlexibleStringListSerializer.kt
@@ -1,0 +1,49 @@
+package com.github.l34130.mise.core.command.serializers
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Mise returns `depends`/`wait_for`/`depends_post` in several shapes depending on how the
+ * task is declared in `mise.toml`:
+ *   - Scalar string: `"echo"`
+ *   - Array of strings (one dep per entry): `["echo", "foo"]`
+ *   - Array of arrays (shell-split args): `[["echo", "'Hello", "World'"]]`
+ *
+ * We normalize every shape to `List<List<String>>`, matching Jackson's previous
+ * `ACCEPT_SINGLE_VALUE_AS_ARRAY` behavior (each scalar becomes a one-element list).
+ */
+object FlexibleStringListSerializer : KSerializer<List<List<String>>> {
+    private val delegate = ListSerializer(ListSerializer(String.serializer()))
+
+    override val descriptor: SerialDescriptor = delegate.descriptor
+
+    override fun deserialize(decoder: Decoder): List<List<String>> {
+        val jsonDecoder = decoder as? JsonDecoder
+            ?: throw SerializationException("FlexibleStringListSerializer only supports JSON")
+        return when (val element = jsonDecoder.decodeJsonElement()) {
+            is JsonPrimitive -> listOf(listOf(element.content))
+            is JsonArray -> element.map { item ->
+                when (item) {
+                    is JsonArray -> item.map { it.jsonPrimitive.content }
+                    is JsonPrimitive -> listOf(item.content)
+                    else -> throw SerializationException("Unexpected element in flexible list: $item")
+                }
+            }
+            else -> throw SerializationException("Unexpected element for flexible list: $element")
+        }
+    }
+
+    override fun serialize(encoder: Encoder, value: List<List<String>>) {
+        encoder.encodeSerializableValue(delegate, value)
+    }
+}


### PR DESCRIPTION
## Summary

Root-cause fix for the `LinkageError` / loader-constraint crashes that #475 worked around by excluding `kotlin-stdlib` from Jackson's transitive deps. Rather than patching the symptom, this PR removes Jackson entirely and migrates the plugin's small JSON surface to `kotlinx.serialization`.

Jackson usage in this plugin is tiny — one parser, five data classes, no polymorphism or custom deserializers — so a full replacement is low-risk and eliminates a whole class of classloader-conflict incidents with other plugins.

## Changes

- **Dependencies**
  - Drop `jackson-module-kotlin` and the `jackson = 2.17.2` version pin.
  - Add `kotlinx-serialization-json 1.9.0` + the Kotlin serialization compiler plugin.
  - Bundle via `implementation` (not `compileOnly`) because the IntelliJ Platform's repackaged `kotlinx.serialization` in `util-8.jar` drops the default impl of `GeneratedSerializer.typeParametersSerializers()`, which triggers `AbstractMethodError` against compiler-generated serializers.
  - Hoist the `org.jetbrains.kotlin` exclude block from #475 onto `runtimeClasspath` / `testRuntimeClasspath` at the root project so `kotlin-stdlib` never enters the plugin ZIP (the per-dependency `exclude { }` does not propagate across project boundaries to `pluginComposedModule(...)` consumers).
- **Data classes** — `@Serializable` + `@SerialName`/`@Transient` on `MiseTask`, `MiseEnv`, `MiseEnvExtended`, `MiseDevTool`, `MiseSource`.
- **`FlexibleStringListSerializer`** — preserves Jackson's `ACCEPT_SINGLE_VALUE_AS_ARRAY` semantics for `depends` / `wait_for` / `depends_post` (scalar, `List<String>`, and `List<List<String>>` inputs all normalize to `List<List<String>>`).
- **Parser** — `MiseCommandLineOutputParser` rewritten on `kotlinx.serialization.Json` with `ignoreUnknownKeys`, `JsonNamingStrategy.SnakeCase`, and `coerceInputValues`.
- **API** — `MiseCommandLine.runCommandLine` collapsed to a single `reified T` overload; `serializer<T>()` replaces the `TypeReference` plumbing. Call sites unchanged.

## Supersedes

- #475 — that PR is a hotfix that only excludes `kotlin-stdlib` from Jackson's transitive deps; this PR removes Jackson entirely, so the same class of conflict cannot recur via Jackson in the future.

## Plugin ZIP verification

```
$ unzip -l build/distributions/mise-5.17.0.zip | grep -iE 'jackson|kotlin-stdlib|kotlinx-serial'
399128  02-01-1980 00:00   mise/lib/kotlinx-serialization-core-jvm-1.9.0.jar
278414  02-01-1980 00:00   mise/lib/kotlinx-serialization-json-jvm-1.9.0.jar
```

- No `jackson-*.jar`
- No `kotlin-stdlib-*.jar`
- `kotlinx-serialization-{core,json}-jvm` are bundled intentionally (see note on the platform's repackaged variant above)

## Test plan

- [x] `./gradlew :mise-core:test` — all parser + merge tests pass (existing `MiseCommandLineOutputParserTest` and `MiseCommandLineHelperMergeTest` kept as a regression safety net; both single-value `depends` and shell-script-style `depends` cases pass)
- [x] `./gradlew build` — full multi-module build green
- [x] Plugin ZIP contents verified (command above)
- [ ] `./gradlew runIde` — manual sanity check: dev tools list, env panel (`mise env --json`, `--json-extended`, `--redacted`), run-configuration env injection, mise tasks tree
- [ ] Install alongside BashSupport Pro to confirm the classloader conflict from #475's upstream issue no longer reproduces

🤖 Generated with [Claude Code](https://claude.com/claude-code)