### PR TITLE
fix: drop inherited read lock in modal executable detection (#484)

### DIFF
--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/cache/MiseCacheService.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/cache/MiseCacheService.kt
@@ -9,6 +9,8 @@ import com.intellij.openapi.components.Service
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.intellij.platform.ide.progress.runWithModalProgressBlocking
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 /**
  * Centralized caching service for all mise-related data using Caffeine.
@@ -103,10 +105,15 @@ class MiseCacheService(private val project: Project) {
             logger.debug("Executable cache miss: $key")
 
             val result = if (ApplicationManager.getApplication().isDispatchThread) {
-                // On EDT - run with modal progress dialog on background thread
+                // On EDT - run with modal progress dialog on background thread.
+                // The modal coroutine can inherit the EDT's read/write-intent lock on newer platform
+                // versions (e.g. 2026.1+), so we explicitly switch to Dispatchers.IO to drop it before
+                // executing the external process.
                 logger.debug("Cache computation triggered from EDT, showing progress dialog")
                 runWithModalProgressBlocking(project, "Detecting mise Executable") {
-                    compute()
+                    withContext(Dispatchers.IO) {
+                        compute()
+                    }
                 }
             } else {
                 // Not on EDT - must not hold a read lock (compute spawns an external process)


### PR DESCRIPTION
## Summary
- Fixes #484. On IntelliJ Platform 2026.1+, `runWithModalProgressBlocking` inherits the EDT's read/write-intent lock into the modal coroutine, which trips the `check(!application.isReadAccessAllowed)` guard in `MiseExecutableManager.runVersionCommand` and throws `IllegalStateException`.
- Wraps the `compute()` call inside `runWithModalProgressBlocking` with `withContext(Dispatchers.IO)` so the external `mise version` process runs off the inherited lock.

## Test plan
- [x] `./gradlew :mise-core:compileKotlin`
- [ ] Reproduce the original stacktrace in IntelliJ IDEA 2026.1.1 and confirm the exception no longer fires when the mise executable cache is cold
- [ ] Sanity-check that the modal progress dialog still appears and dismisses correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)