### PR TITLE
feat: add "Use in IDE terminal" setting (#485)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Features
+
+- Add "Use in IDE terminal" setting to opt the JediTerm terminal out of mise env injection independently of other command lines (#485)
+
 ## [5.18.0] - 2026-04-19
 
 ### Fixes

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/command/MiseCommandLineEnvCustomizer.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/command/MiseCommandLineEnvCustomizer.kt
@@ -19,6 +19,7 @@ import kotlin.io.path.Path
  *
  * When used directly, it acts as a catch-all for terminal commands, external tools,
  * build tools, etc. Controlled by the "Use in all other command line execution" setting.
+ * The IDE terminal can additionally be opted out via the "Use in IDE terminal" sub-setting.
  *
  * Double-customization is prevented by checking for the marker added by
  * MiseHelper.getMiseEnvVarsOrNotify().
@@ -54,6 +55,15 @@ open class MiseCommandLineEnvCustomizer : CommandLineEnvCustomizer, MiseEnvCusto
 
         // Perform checks that need the project (can be overridden by subclasses)
         if (!shouldCustomizeForProject(project, commandLine)) return
+
+        // Allow users to opt the IDE terminal out independently of other command lines (issue #485).
+        // Detected via TERMINAL_EMULATOR=JetBrains-JediTerm, which the platform sets before
+        // env customizers run.
+        if (isIdeTerminalCommand(commandLine) &&
+            !project.service<MiseProjectSettings>().state.useMiseInTerminal) {
+            logger.trace(logMessage("Skipping environment customization of IDE terminal.", commandLine))
+            return
+        }
 
         val workDir = MiseCommandLineHelper.resolveWorkingDirectory(commandLine, project)
 
@@ -95,6 +105,17 @@ open class MiseCommandLineEnvCustomizer : CommandLineEnvCustomizer, MiseEnvCusto
      * while the platform is still initializing WSL state.
      */
     private fun isIdeWslExeCommand(commandLine: GeneralCommandLine): Boolean = Path(commandLine.exePath) == WSLDistribution.findWslExe()
+
+    /**
+     * Identify command lines originating from the IDE's built-in terminal (JediTerm).
+     *
+     * The terminal runner stamps `TERMINAL_EMULATOR=JetBrains-JediTerm` into the env map
+     * before any [CommandLineEnvCustomizer] runs, so it survives to this point. This is
+     * preferable to instance-checking [com.intellij.execution.configurations.PtyCommandLine],
+     * which is also used by run configurations (e.g. mise task runners) we still want to customize.
+     */
+    private fun isIdeTerminalCommand(commandLine: GeneralCommandLine): Boolean =
+        commandLine.environment["TERMINAL_EMULATOR"] == "JetBrains-JediTerm"
 
     private fun logMessage(message: String, commandLine: GeneralCommandLine) = "$message (cmd=$commandLine, workingDirectory=${commandLine.workingDirectory})"
 }

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/setting/MiseConfigurable.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/setting/MiseConfigurable.kt
@@ -19,6 +19,7 @@ import com.intellij.ui.dsl.builder.AlignX
 import com.intellij.ui.dsl.builder.COLUMNS_MEDIUM
 import com.intellij.ui.dsl.builder.columns
 import com.intellij.ui.dsl.builder.panel
+import com.intellij.ui.layout.ComponentPredicate
 import com.intellij.ui.layout.selected
 import com.intellij.util.application
 import javax.swing.JComponent
@@ -43,6 +44,7 @@ class MiseConfigurable(
     private val myMiseDatabaseCb = JBCheckBox("Use in database authentication")
     private val myMiseNxCb = JBCheckBox("Use in Nx commands")
     private val myMiseAllCommandLinesCb = JBCheckBox("Use in all other command line execution")
+    private val myMiseTerminalCb = JBCheckBox("Use in IDE terminal")
 
     override fun getDisplayName(): String = "Mise Settings"
 
@@ -77,6 +79,7 @@ class MiseConfigurable(
         myMiseDatabaseCb.isSelected = projectSettings.state.useMiseInDatabaseAuthentication
         myMiseNxCb.isSelected = projectSettings.state.useMiseInNxCommands
         myMiseAllCommandLinesCb.isSelected = projectSettings.state.useMiseInAllCommandLines
+        myMiseTerminalCb.isSelected = projectSettings.state.useMiseInTerminal
 
         // Set placeholder text for auto-detected path
         val autoDetectedInfo = executableManager.getAutoDetectedExecutableInfo()
@@ -179,8 +182,26 @@ class MiseConfigurable(
                             row {
                                 cell(myMiseAllCommandLinesCb)
                                     .resizableColumn()
-                                    .comment("Inject into all other command line execution (terminal, external tools, etc.)")
+                                    .comment("Inject into all other command line execution (external tools, build tools, etc.)")
                             }.enabledIf(myMiseDirEnvCb.selected)
+
+                            indent {
+                                row {
+                                    cell(myMiseTerminalCb)
+                                        .resizableColumn()
+                                        .comment("Inject into the IDE built-in terminal. Disable to keep the terminal's environment untouched (e.g. so <code>.ruby-version</code> still controls the active Ruby).")
+                                }.enabledIf(
+                                    object : ComponentPredicate() {
+                                        override fun invoke(): Boolean =
+                                            myMiseDirEnvCb.isSelected && myMiseAllCommandLinesCb.isSelected
+
+                                        override fun addListener(listener: (Boolean) -> Unit) {
+                                            myMiseDirEnvCb.addItemListener { listener(invoke()) }
+                                            myMiseAllCommandLinesCb.addItemListener { listener(invoke()) }
+                                        }
+                                    },
+                                )
+                            }
                         }
                     }
                 }
@@ -212,7 +233,8 @@ class MiseConfigurable(
             myMiseVcsCb.isSelected != projectSettings.state.useMiseVcsIntegration ||
             myMiseDatabaseCb.isSelected != projectSettings.state.useMiseInDatabaseAuthentication ||
             myMiseNxCb.isSelected != projectSettings.state.useMiseInNxCommands ||
-            myMiseAllCommandLinesCb.isSelected != projectSettings.state.useMiseInAllCommandLines
+            myMiseAllCommandLinesCb.isSelected != projectSettings.state.useMiseInAllCommandLines ||
+            myMiseTerminalCb.isSelected != projectSettings.state.useMiseInTerminal
     }
 
     override fun apply() {
@@ -241,6 +263,7 @@ class MiseConfigurable(
             projectSettings.state.useMiseInDatabaseAuthentication = myMiseDatabaseCb.isSelected
             projectSettings.state.useMiseInNxCommands = myMiseNxCb.isSelected
             projectSettings.state.useMiseInAllCommandLines = myMiseAllCommandLinesCb.isSelected
+            projectSettings.state.useMiseInTerminal = myMiseTerminalCb.isSelected
 
             // Notify listeners that settings have changed
             MiseProjectEventListener.broadcast(

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/setting/MiseProjectSettings.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/setting/MiseProjectSettings.kt
@@ -38,6 +38,7 @@ class MiseProjectSettings : PersistentStateComponent<MiseProjectSettings.MyState
                 it.useMiseInDatabaseAuthentication = myState.useMiseInDatabaseAuthentication
                 it.useMiseInNxCommands = myState.useMiseInNxCommands
                 it.useMiseInAllCommandLines = myState.useMiseInAllCommandLines
+                it.useMiseInTerminal = myState.useMiseInTerminal
             }
     }
 
@@ -52,6 +53,11 @@ class MiseProjectSettings : PersistentStateComponent<MiseProjectSettings.MyState
         var useMiseInDatabaseAuthentication: Boolean = true
         var useMiseInNxCommands: Boolean = true
         var useMiseInAllCommandLines: Boolean = false  // Conservative default
+        // Additional gate that only applies when useMiseInAllCommandLines is enabled.
+        // Defaults to true so existing users with useMiseInAllCommandLines=true keep
+        // current behavior; flipping this to false lets users opt the IDE terminal out
+        // while keeping injection for other command lines (see issue #485).
+        var useMiseInTerminal: Boolean = true
 
         // Deprecated fields - kept for backward compatibility during deserialization
         @Deprecated("Use executablePath instead")
@@ -70,6 +76,7 @@ class MiseProjectSettings : PersistentStateComponent<MiseProjectSettings.MyState
                 it.useMiseInDatabaseAuthentication = useMiseInDatabaseAuthentication
                 it.useMiseInNxCommands = useMiseInNxCommands
                 it.useMiseInAllCommandLines = useMiseInAllCommandLines
+                it.useMiseInTerminal = useMiseInTerminal
             }
     }
 }

--- a/modules/core/src/test/kotlin/com/github/l34130/mise/core/command/MiseCommandLineEnvCustomizerTest.kt
+++ b/modules/core/src/test/kotlin/com/github/l34130/mise/core/command/MiseCommandLineEnvCustomizerTest.kt
@@ -1,12 +1,43 @@
 package com.github.l34130.mise.core.command
 
+import com.github.l34130.mise.core.setting.MiseProjectSettings
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.service
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
 class MiseCommandLineEnvCustomizerTest : BasePlatformTestCase() {
+
+    fun `test IDE terminal command lines are skipped when useMiseInTerminal is disabled`() {
+        val settings = project.service<MiseProjectSettings>().state
+        val originalUseMiseInTerminal = settings.useMiseInTerminal
+        val originalUseMiseInAllCommandLines = settings.useMiseInAllCommandLines
+        try {
+            settings.useMiseInAllCommandLines = true
+            settings.useMiseInTerminal = false
+
+            val customizer = MiseCommandLineEnvCustomizer()
+            val commandLine = GeneralCommandLine("dummy-shell")
+                .withWorkDirectory(project.basePath)
+                .withEnvironment("TERMINAL_EMULATOR", "JetBrains-JediTerm")
+            val env = commandLine.environment
+
+            customizer.customizeEnv(commandLine, env)
+
+            // Nothing from mise should have been injected — the only entry is the JediTerm marker
+            // the test set itself.
+            assertEquals(mapOf("TERMINAL_EMULATOR" to "JetBrains-JediTerm"), env)
+            assertTrue(
+                "Env map identity must NOT be marked as customized when terminal injection is opted out",
+                MiseCommandLineHelper.environmentNeedsCustomization(env),
+            )
+        } finally {
+            settings.useMiseInTerminal = originalUseMiseInTerminal
+            settings.useMiseInAllCommandLines = originalUseMiseInAllCommandLines
+        }
+    }
 
     fun `test environment customization avoids deadlock when write action is active`() {
         val customizer = MiseCommandLineEnvCustomizer()


### PR DESCRIPTION
## Summary

- Adds a new project-level toggle `useMiseInTerminal` (default `true`) nested under "Use in all other command line execution", letting users keep mise env injection for external tools / build commands while opting the IDE terminal out.
- `MiseCommandLineEnvCustomizer` now skips injection when the command line carries `TERMINAL_EMULATOR=JetBrains-JediTerm` (set by the platform's terminal runner) and the new toggle is `false`. PtyCommandLine instance detection was avoided because mise's own task run config also uses `PtyCommandLine`.
- Default is `true` so existing users with `useMiseInAllCommandLines = true` keep current behavior.

Fixes #485

## Test plan

- [x] `./gradlew :mise-core:compileKotlin` — succeeds
- [x] `./gradlew compileKotlin` — full multi-module build succeeds
- [x] New unit test `test IDE terminal command lines are skipped when useMiseInTerminal is disabled` passes
- [x] `./gradlew :mise-core:test` — 106/107 pass; the single failing test (`test environment customization avoids deadlock when write action is active`) already fails on `main` without these changes
- [ ] Manual: open Settings → Tools → Mise Settings, verify the new "Use in IDE terminal" checkbox appears under the all-other-command-lines toggle and disables when the parent is off
- [ ] Manual (RubyMine, the reporter's IDE): enable "Use in all other command line execution", uncheck "Use in IDE terminal", open a new terminal tab, confirm `env | grep MISE_RUBY_VERSION` is empty while a Gradle run still picks up mise env

🤖 Generated with [Claude Code](https://claude.com/claude-code)