### PR TITLE
fix: escape modal coroutine lock context for mise detection

### DIFF
--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/cache/MiseCacheService.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/cache/MiseCacheService.kt
@@ -9,8 +9,10 @@ import com.intellij.openapi.components.Service
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.intellij.platform.ide.progress.runWithModalProgressBlocking
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.async
 
 /**
  * Centralized caching service for all mise-related data using Caffeine.
@@ -22,7 +24,7 @@ import kotlinx.coroutines.withContext
  * All mise caching should go through this service for consistent behavior and observability.
  */
 @Service(Service.Level.PROJECT)
-class MiseCacheService(private val project: Project) {
+class MiseCacheService(private val project: Project, private val cs: CoroutineScope) {
     private val logger = logger<MiseCacheService>()
 
     /**
@@ -106,13 +108,19 @@ class MiseCacheService(private val project: Project) {
 
             val result = if (ApplicationManager.getApplication().isDispatchThread) {
                 // On EDT - run with modal progress dialog on background thread.
-                // The modal coroutine can inherit the EDT's read/write-intent lock on newer platform
-                // versions (e.g. 2026.1+), so we explicitly switch to Dispatchers.IO to drop it before
-                // executing the external process.
+                // The modal coroutine inherits the EDT's read/write-intent lock via coroutine context
+                // on newer platform versions (2026.1+), so switching dispatchers inside the modal block
+                // is not enough to drop it. Launch the work in the service's own coroutine scope, which
+                // has a fresh context with no inherited locks, and await its result from within the
+                // modal progress.
                 logger.debug("Cache computation triggered from EDT, showing progress dialog")
+                val deferred = cs.async(Dispatchers.IO) { compute() }
                 runWithModalProgressBlocking(project, "Detecting mise Executable") {
-                    withContext(Dispatchers.IO) {
-                        compute()
+                    try {
+                        deferred.await()
+                    } catch (e: CancellationException) {
+                        deferred.cancel()
+                        throw e
                     }
                 }
             } else {

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/cache/MiseCacheService.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/cache/MiseCacheService.kt
@@ -103,38 +103,44 @@ class MiseCacheService(private val project: Project, private val cs: CoroutineSc
      * EDT callers are safe because [runWithModalProgressBlocking] dispatches to a background coroutine.
      */
     fun getOrComputeExecutable(key: String, compute: () -> MiseExecutableInfo): MiseExecutableInfo {
-        return executableCache.get(key) {
-            logger.debug("Executable cache miss: $key")
+        // Fast path: return cached value without engaging the Caffeine loader.
+        executableCache.getIfPresent(key)?.let { return it }
 
-            val result = if (ApplicationManager.getApplication().isDispatchThread) {
-                // On EDT - run with modal progress dialog on background thread.
-                // The modal coroutine inherits the EDT's read/write-intent lock via coroutine context
-                // on newer platform versions (2026.1+), so switching dispatchers inside the modal block
-                // is not enough to drop it. Launch the work in the service's own coroutine scope, which
-                // has a fresh context with no inherited locks, and await its result from within the
-                // modal progress.
-                logger.debug("Cache computation triggered from EDT, showing progress dialog")
-                val deferred = cs.async(Dispatchers.IO) { compute() }
-                runWithModalProgressBlocking(project, "Detecting mise Executable") {
-                    try {
-                        deferred.await()
-                    } catch (e: CancellationException) {
-                        deferred.cancel()
-                        throw e
-                    }
+        // Compute OUTSIDE the cache loader. Running modal/blocking work inside `cache.get(key) { ... }`
+        // is unsafe: Caffeine holds a per-key lock for the duration of the mapping function, and the
+        // modal event loop on EDT can dispatch events that re-enter this method for the same key,
+        // producing a self-deadlock. `mise --version` is idempotent, so racing computations on
+        // background threads are acceptable; the last write wins.
+        logger.debug("Executable cache miss: $key")
+        val result = if (ApplicationManager.getApplication().isDispatchThread) {
+            // On EDT - run with modal progress dialog on background thread.
+            // The modal coroutine inherits the EDT's read/write-intent lock via coroutine context
+            // on newer platform versions (2026.1+), so switching dispatchers inside the modal block
+            // is not enough to drop it. Launch the work in the service's own coroutine scope, which
+            // has a fresh context with no inherited locks, and await its result from within the
+            // modal progress.
+            logger.debug("Cache computation triggered from EDT, showing progress dialog")
+            val deferred = cs.async(Dispatchers.IO) { compute() }
+            runWithModalProgressBlocking(project, "Detecting mise Executable") {
+                try {
+                    deferred.await()
+                } catch (e: CancellationException) {
+                    deferred.cancel()
+                    throw e
                 }
-            } else {
-                // Not on EDT - must not hold a read lock (compute spawns an external process)
-                check(!ApplicationManager.getApplication().isReadAccessAllowed) {
-                    "getOrComputeExecutable must not be called under a read lock from a background thread. " +
-                    "Wrap the call site in a coroutine launched on Dispatchers.IO instead."
-                }
-                compute()
             }
-
-            logger.debug("Executable cached: $key")
-            result
+        } else {
+            // Not on EDT - must not hold a read lock (compute spawns an external process)
+            check(!ApplicationManager.getApplication().isReadAccessAllowed) {
+                "getOrComputeExecutable must not be called under a read lock from a background thread. " +
+                "Wrap the call site in a coroutine launched on Dispatchers.IO instead."
+            }
+            compute()
         }
+
+        executableCache.put(key, result)
+        logger.debug("Executable cached: $key")
+        return result
     }
 
     fun getCachedExecutable(key: String): MiseExecutableInfo? {


### PR DESCRIPTION
## Summary
- Follow-up to #489. The previous fix wrapped `compute()` with `withContext(Dispatchers.IO)` inside `runWithModalProgressBlocking`, but on IntelliJ Platform 2026.1+ the read/write-intent lock is carried in the **coroutine context**, not the thread. Switching dispatchers therefore does not drop the lock, and `MiseExecutableManager.runVersionCommand` still trips its `check(!application.isReadAccessAllowed)` guard when the settings page (`MiseConfigurable.createComponent`) opens with a cold executable cache, throwing `IllegalStateException: runVersionCommand must not be called while holding a read lock` and breaking the configurable.
- Launch `compute()` from the service's own `CoroutineScope` (`cs.async(Dispatchers.IO) { compute() }`) instead. That scope is created independently of the EDT, so it does not inherit the modal lock context, and the external `mise version` process runs lock-free. `runWithModalProgressBlocking` just awaits the deferred; on cancellation we cancel it to avoid stranding work.

## Test plan
- [x] `./gradlew :mise-core:compileKotlin`
- [x] `./gradlew :mise-core:compileTestKotlin`
- [ ] Reproduce the original stacktrace in IntelliJ IDEA 2026.1.x with a cold executable cache and confirm the settings page now opens cleanly
- [ ] Sanity-check that the modal progress dialog still appears, dismisses correctly, and cancellation does not leak the background detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)