### PR TITLE
fix(nodejs): use WslNodeInterpreter for WSL-resolved Node.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Fixes
+
+- Use `WslNodeInterpreter` for WSL-resolved Node.js so IntelliJ can address it as `wsl://<distro>@/...` instead of the broken `\\wsl.localhost\<distro>\...` UNC path
+
 ## [5.18.0] - 2026-04-19
 
 ### Fixes

--- a/modules/products/nodejs/build.gradle.kts
+++ b/modules/products/nodejs/build.gradle.kts
@@ -34,3 +34,9 @@ dependencies {
         testImplementation("org.opentest4j:opentest4j:1.3.0")
     }
 }
+
+tasks.test {
+    if (!System.getProperty("os.name").contains("Windows", ignoreCase = true)) {
+        exclude("**/MiseProjectInterpreterSetupWslTest.class")
+    }
+}

--- a/modules/products/nodejs/src/main/kotlin/com/github/l34130/mise/nodejs/node/MiseProjectInterpreterSetup.kt
+++ b/modules/products/nodejs/src/main/kotlin/com/github/l34130/mise/nodejs/node/MiseProjectInterpreterSetup.kt
@@ -3,9 +3,12 @@ package com.github.l34130.mise.nodejs.node
 import com.github.l34130.mise.core.command.MiseDevTool
 import com.github.l34130.mise.core.command.MiseDevToolName
 import com.github.l34130.mise.core.setup.AbstractProjectSdkSetup
+import com.github.l34130.mise.core.wsl.WslPathUtils
 import com.intellij.javascript.nodejs.interpreter.NodeJsInterpreter
 import com.intellij.javascript.nodejs.interpreter.NodeJsInterpreterManager
 import com.intellij.javascript.nodejs.interpreter.local.NodeJsLocalInterpreter
+import com.intellij.javascript.nodejs.interpreter.wsl.WslNodeInterpreter
+import com.intellij.javascript.nodejs.interpreter.wsl.WslNodeInterpreterManager
 import com.intellij.javascript.nodejs.settings.NodeSettingsConfigurable
 import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.application.WriteAction
@@ -26,12 +29,12 @@ class MiseProjectInterpreterSetup : AbstractProjectSdkSetup() {
             ReadAction.compute<NodeJsInterpreter?, Throwable> {
                 nodeJsInterpreterManager.interpreter
             }
-        val newInterpreter = tool.asNodeJsLocalInterpreter(project)
+        val newInterpreter = tool.asNodeJsInterpreter(project)
 
         if (currentInterpreter == null || !currentInterpreter.deepEquals(newInterpreter)) {
             return SdkStatus.NeedsUpdate(
                 currentSdkVersion = currentInterpreter?.cachedVersion?.get()?.parsedVersion,
-                requestedInstallPath = newInterpreter.interpreterSystemDependentPath,
+                requestedInstallPath = newInterpreter.presentableName,
             )
         }
 
@@ -43,14 +46,17 @@ class MiseProjectInterpreterSetup : AbstractProjectSdkSetup() {
         project: Project,
     ): ApplySdkResult {
         val nodeJsInterpreterManager = NodeJsInterpreterManager.getInstance(project)
-        val newInterpreter = tool.asNodeJsLocalInterpreter(project)
+        val newInterpreter = tool.asNodeJsInterpreter(project)
 
         return WriteAction.computeAndWait<ApplySdkResult, Throwable> {
+            if (newInterpreter is WslNodeInterpreter) {
+                registerWslInterpreter(newInterpreter)
+            }
             nodeJsInterpreterManager.setInterpreterRef(newInterpreter.toRef())
             ApplySdkResult(
                 sdkName = newInterpreter.presentableName,
                 sdkVersion = newInterpreter.cachedVersion?.get()?.parsedVersion ?: tool.displayVersion,
-                sdkPath = newInterpreter.interpreterSystemDependentPath,
+                sdkPath = newInterpreter.presentableName,
             )
         }
     }
@@ -58,8 +64,40 @@ class MiseProjectInterpreterSetup : AbstractProjectSdkSetup() {
     @Suppress("UNCHECKED_CAST")
     override fun <T : Configurable> getConfigurableClass(): KClass<out T> = NodeSettingsConfigurable::class as KClass<out T>
 
-    private fun MiseDevTool.asNodeJsLocalInterpreter(project: Project): NodeJsLocalInterpreter =
-        getToolBinPath(project)
-            .getOrElse { e -> throw IllegalStateException("Failed to create NodePackage for ${getDevToolName(project).value}", e) }
-            .let { NodeJsLocalInterpreter(it) }
+    private fun MiseDevTool.asNodeJsInterpreter(project: Project): NodeJsInterpreter {
+        val devToolName = getDevToolName(project).value
+        val binPath = getToolBinPath(project)
+            .getOrElse { e -> throw IllegalStateException("Failed to create Node interpreter for $devToolName", e) }
+        return createNodeJsInterpreter(binPath, this.wslDistributionMsId)
+    }
+
+    private fun registerWslInterpreter(interpreter: WslNodeInterpreter) {
+        val manager = WslNodeInterpreterManager.getInstance() ?: return
+        val existing = manager.interpreters
+        val alreadyRegistered = existing.any {
+            it.wslDistributionId == interpreter.wslDistributionId &&
+                it.wslInterpreterPath == interpreter.wslInterpreterPath
+        }
+        if (!alreadyRegistered) {
+            manager.interpreters = existing + interpreter
+        }
+    }
+
+    companion object {
+        /**
+         * Picks the right [NodeJsInterpreter] flavor for a mise-managed node binary.
+         *
+         * For WSL-resolved tools, IntelliJ requires [WslNodeInterpreter] referenced as
+         * `wsl://<distro>@/<unix-path>` — feeding it the `\\wsl.localhost\<distro>\...` UNC path
+         * via [NodeJsLocalInterpreter] yields a broken `C:/home/<user>/...` resolution.
+         * See https://github.com/134130/intellij-mise/issues/476.
+         */
+        internal fun createNodeJsInterpreter(binPath: String, wslDistributionMsId: String?): NodeJsInterpreter {
+            if (wslDistributionMsId != null) {
+                val unixBinPath = WslPathUtils.convertWindowsUncToUnixPath(binPath) ?: binPath
+                return WslNodeInterpreter(wslDistributionMsId, unixBinPath)
+            }
+            return NodeJsLocalInterpreter(binPath)
+        }
+    }
 }

--- a/modules/products/nodejs/src/test/kotlin/com/github/l34130/mise/nodejs/node/MiseProjectInterpreterSetupTest.kt
+++ b/modules/products/nodejs/src/test/kotlin/com/github/l34130/mise/nodejs/node/MiseProjectInterpreterSetupTest.kt
@@ -1,0 +1,21 @@
+package com.github.l34130.mise.nodejs.node
+
+import com.intellij.javascript.nodejs.interpreter.local.NodeJsLocalInterpreter
+import com.intellij.testFramework.LightPlatformTestCase
+
+class MiseProjectInterpreterSetupTest : LightPlatformTestCase() {
+    fun `test creates NodeJsLocalInterpreter when no WSL distribution`() {
+        val interpreter = MiseProjectInterpreterSetup.createNodeJsInterpreter(
+            binPath = "/usr/local/bin/node",
+            wslDistributionMsId = null,
+        )
+        assertTrue(
+            "Expected NodeJsLocalInterpreter but was ${interpreter::class.simpleName}",
+            interpreter is NodeJsLocalInterpreter,
+        )
+        assertEquals(
+            "/usr/local/bin/node",
+            (interpreter as NodeJsLocalInterpreter).interpreterSystemIndependentPath,
+        )
+    }
+}

--- a/modules/products/nodejs/src/test/kotlin/com/github/l34130/mise/nodejs/node/MiseProjectInterpreterSetupWslTest.kt
+++ b/modules/products/nodejs/src/test/kotlin/com/github/l34130/mise/nodejs/node/MiseProjectInterpreterSetupWslTest.kt
@@ -1,0 +1,32 @@
+package com.github.l34130.mise.nodejs.node
+
+import com.intellij.javascript.nodejs.interpreter.wsl.WslNodeInterpreter
+import com.intellij.testFramework.LightPlatformTestCase
+
+/**
+ * WSL-only tests for [MiseProjectInterpreterSetup].
+ *
+ * Excluded on non-Windows hosts via the module's `build.gradle.kts`, because
+ * IntelliJ's WSL services are only wired up on Windows.
+ */
+class MiseProjectInterpreterSetupWslTest : LightPlatformTestCase() {
+    fun `test creates WslNodeInterpreter with unix path when distribution is set`() {
+        val uncPath = "\\\\wsl.localhost\\Ubuntu\\home\\user\\.local\\share\\mise\\installs\\node\\22.0.0\\bin\\node"
+        val interpreter = MiseProjectInterpreterSetup.createNodeJsInterpreter(
+            binPath = uncPath,
+            wslDistributionMsId = "Ubuntu",
+        )
+        assertTrue(
+            "Expected WslNodeInterpreter but was ${interpreter::class.simpleName}",
+            interpreter is WslNodeInterpreter,
+        )
+        interpreter as WslNodeInterpreter
+        assertEquals("Ubuntu", interpreter.wslDistributionId)
+        // The buggy behavior was returning a path like C:/home/user/... or a raw UNC path;
+        // IntelliJ expects the WSL-internal unix path so it can construct a wsl:// reference.
+        assertEquals(
+            "/home/user/.local/share/mise/installs/node/22.0.0/bin/node",
+            interpreter.wslInterpreterPath,
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Fixes #476 — WSL-installed Node.js was resolved to `C:/home/<user>/...` because the plugin handed `IntelliJ`'s `NodeJsLocalInterpreter` a `\\wsl.localhost\<distro>\...` UNC path. As @cyyynthia noted, the JS plugin expects WSL Node referenced as `wsl://<distro>@/<unix-path>` via `WslNodeInterpreter`.
- When `MiseDevTool.wslDistributionMsId` is set, build a `WslNodeInterpreter` from the WSL-internal Unix path (recovered by inverting the UNC conversion) and register it on `WslNodeInterpreterManager` so `setInterpreterRef` resolves it.

## Test plan

- [x] `:mise-products-nodejs:check` (macOS) — `MiseProjectInterpreterSetupTest` covers the local-interpreter path.
- [ ] `:mise-products-nodejs:check` on Windows — `MiseProjectInterpreterSetupWslTest` (excluded on non-Windows) verifies the WSL branch creates a `WslNodeInterpreter` pointing at the WSL-internal unix path.
- [ ] Manual: open a WSL-hosted project in IntelliJ on Windows with `mise use node@<v>` and confirm the Node.js settings page lists the interpreter as `wsl://<distro>@/.../bin/node` and that `node --version` works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)