### PR TITLE
Fix .mise.toml depends showing non-project depends, and fix Settings bug due to 2026.x locking changes

### DIFF
--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/command/MiseExecutableManager.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/command/MiseExecutableManager.kt
@@ -192,6 +192,13 @@ class MiseExecutableManager(
 
     fun getAutoDetectedExecutableInfo(): MiseExecutableInfo = getAutoDetectedInfo()
 
+    /**
+     * Returns the cached auto-detected executable info without triggering detection.
+     * Safe to call from EDT or under a read lock. Returns null if the cache is cold.
+     */
+    fun getAutoDetectedExecutableInfoIfCached(): MiseExecutableInfo? =
+        cacheService.getCachedExecutable(AUTO_DETECTED_KEY)
+
     private fun getAutoDetectedInfo(): MiseExecutableInfo {
         return cacheService.getOrComputeExecutable(AUTO_DETECTED_KEY) {
             val projectPath = project.guessMiseProjectPath()

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/lang/completion/MiseTomlTaskCompletionProvider.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/lang/completion/MiseTomlTaskCompletionProvider.kt
@@ -89,7 +89,13 @@ class MiseTomlTaskCompletionProvider : CompletionProvider<CompletionParameters>(
         }
         if (currentTaskSegment == null) return
 
-        for (task in project.service<MiseTaskResolver>().getCachedTasksOrEmptyList()) {
+        // Deduplicate by task name: mise resolves configs from general to specific,
+        // so the last task for a given name is the highest-precedence definition.
+        // Deduplicate by task name: mise resolves configs from general to specific,
+        // so the last task for a given name is the highest-precedence definition.
+        val allTasks = project.service<MiseTaskResolver>().getCachedTasksOrEmptyList()
+            .associateBy { it.name }.values
+        for (task in allTasks) {
             if (dependsArray?.elements?.any { it.stringValue == task.name } == true) continue
             if (task.name == currentTaskSegment.name) continue
 

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/lang/completion/MiseTomlTaskCompletionProvider.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/lang/completion/MiseTomlTaskCompletionProvider.kt
@@ -91,8 +91,6 @@ class MiseTomlTaskCompletionProvider : CompletionProvider<CompletionParameters>(
 
         // Deduplicate by task name: mise resolves configs from general to specific,
         // so the last task for a given name is the highest-precedence definition.
-        // Deduplicate by task name: mise resolves configs from general to specific,
-        // so the last task for a given name is the highest-precedence definition.
         val allTasks = project.service<MiseTaskResolver>().getCachedTasksOrEmptyList()
             .associateBy { it.name }.values
         for (task in allTasks) {

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/lang/resolve/MiseTomlTaskDependencyReferenceProvider.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/lang/resolve/MiseTomlTaskDependencyReferenceProvider.kt
@@ -51,19 +51,27 @@ class MiseTomlTaskDependencyReferenceProvider : PsiReferenceProvider() {
             val project = element.project
             val resolver = project.service<MiseTaskResolver>()
             val tasks = resolver.getCachedTasksOrEmptyList()
-            val result =
+            // Deduplicate by task name: mise resolves configs from general to specific,
+            // so the last task for a given name is the highest-precedence definition.
+            val matchedTasks =
                 if (isWildcard) {
-                    // FIXME: IDK why this is not working
                     tasks.filter { it.name.startsWith(value.dropLast(1)) }
                 } else {
                     tasks.filter { it.name == value }
-                }.mapNotNull {
-                    when (it) {
-                        is MiseShellScriptTask -> it.file.findPsiFile(project)
-                        is MiseTomlTableTask -> it.keySegment
-                        is MiseUnknownTask -> null
-                    }
+                }.associateBy { it.name }.values
+
+            val currentFilePath = element.containingFile?.virtualFile?.path
+            val result = matchedTasks.mapNotNull { task ->
+                when (task) {
+                    is MiseShellScriptTask -> task.file.takeIf { f -> f.isValid }?.findPsiFile(project)
+                    is MiseTomlTableTask -> task.keySegment.takeIf { seg -> seg.isValid }
+                    is MiseUnknownTask -> null
                 }
+            }.let { elements ->
+                // Prefer the definition from the same file as the reference
+                val sameFile = elements.filter { it.containingFile?.virtualFile?.path == currentFilePath }
+                sameFile.ifEmpty { elements }
+            }
 
             return PsiElementResolveResult.createResults(result)
         }

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/setting/MiseConfigurable.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/setting/MiseConfigurable.kt
@@ -78,10 +78,11 @@ class MiseConfigurable(
         myMiseNxCb.isSelected = projectSettings.state.useMiseInNxCommands
         myMiseAllCommandLinesCb.isSelected = projectSettings.state.useMiseInAllCommandLines
 
-        // Set placeholder text for auto-detected path
-        val autoDetectedInfo = executableManager.getAutoDetectedExecutableInfo()
-        val autoDetectedPath = autoDetectedInfo.path
-        val autoDetectedVersion = autoDetectedInfo.version?.toString()
+        // Set placeholder text for auto-detected path (non-blocking cache lookup to avoid
+        // triggering executable detection under the settings dialog's read lock)
+        val autoDetectedInfo = executableManager.getAutoDetectedExecutableInfoIfCached()
+        val autoDetectedPath = autoDetectedInfo?.path ?: "mise"
+        val autoDetectedVersion = autoDetectedInfo?.version?.toString()
         val autoDetectedLabel = if (autoDetectedVersion != null) {
             "Auto-detected: $autoDetectedPath (version: $autoDetectedVersion)"
         } else {


### PR DESCRIPTION
<img width="667" height="375" alt="image" src="https://github.com/user-attachments/assets/0fdeddb3-97d7-454d-8c8b-f1bb85eaa3ce" />

More info in the commits, nice easy change in the end. Been bugging me for a while.

Fixes #494