### PR TITLE
fix: resolve non-project depends issue while supporting subdirectory configs

### DIFF
--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/MiseConfigFileResolver.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/MiseConfigFileResolver.kt
@@ -106,11 +106,11 @@ class MiseConfigFileResolver(
         baseDirVf: VirtualFile,
         configEnvironment: String?,
     ): List<VirtualFile> {
-        val tracked =
-            MiseCommandLineHelper.getTrackedConfigs(project, configEnvironment.orEmpty())
+        val activeConfigs =
+            MiseCommandLineHelper.getProjectTrackedConfigs(project, configEnvironment)
                 .getOrElse { return emptyList() }
         val fs = LocalFileSystem.getInstance()
-        return tracked
+        return activeConfigs
             .asSequence()
             .filter { it.endsWith(".toml", ignoreCase = true) }
             .mapNotNull { fs.refreshAndFindFileByPath(it) }

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/command/MiseCommandLineHelper.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/command/MiseCommandLineHelper.kt
@@ -331,14 +331,17 @@ object MiseCommandLineHelper {
         trackedConfigs: List<String>,
         workDir: String,
     ): List<String> {
-        val normalizedWorkDir = Paths.get(workDir).normalize().toString().replace('\\', '/')
+        val normalizedWorkDir = normalizeConfigPathForComparison(workDir)
         val workDirPrefix = if (normalizedWorkDir.endsWith("/")) normalizedWorkDir else "$normalizedWorkDir/"
         val projectTrackedConfigs = trackedConfigs.filter {
-            val normalizedPath = Paths.get(it).normalize().toString().replace('\\', '/')
+            val normalizedPath = normalizeConfigPathForComparison(it)
             normalizedPath.startsWith(workDirPrefix) || normalizedPath == normalizedWorkDir
         }
         return (activeConfigs.reversed() + projectTrackedConfigs).distinct()
     }
+
+    private fun normalizeConfigPathForComparison(path: String): String =
+        Paths.get(maybeConvertWindowsUncToUnixPath(path)).normalize().toString().replace('\\', '/')
 
     // mise exec
     @RequiresBackgroundThread

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/command/MiseCommandLineHelper.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/command/MiseCommandLineHelper.kt
@@ -292,19 +292,32 @@ object MiseCommandLineHelper {
         return miseCommandLine.runRawCommandLine(commandLineArgs)
     }
 
-    // mise config --tracked-configs
+    // mise config ls --json + mise config --tracked-configs
     @RequiresBackgroundThread
-    fun getTrackedConfigs(
+    fun getProjectTrackedConfigs(
         project: Project,
-        configEnvironment: String,
+        configEnvironment: String?,
         workDir: String = project.guessMiseProjectPath(),
     ): Result<List<String>> {
-        val commandLineArgs = mutableListOf("config", "--tracked-configs")
-
         val miseCommandLine = MiseCommandLine(project, workDir, configEnvironment)
-        return miseCommandLine
-            .runRawCommandLine(commandLineArgs)
+        
+        val activeConfigs = miseCommandLine
+            .runCommandLine<List<MiseConfigLsOutput>>(listOf("config", "ls", "--json"))
+            .map { list -> list.map { it.path } }
+            .getOrElse { emptyList() }
+            
+        val trackedConfigs = miseCommandLine
+            .runRawCommandLine(listOf("config", "--tracked-configs"))
             .map { it.lines().map { line -> line.trim() }.filter { trimmed -> trimmed.isNotEmpty() } }
+            .getOrElse { emptyList() }
+            
+        val workDirPath = java.nio.file.Paths.get(workDir).normalize().toString().replace('\\', '/')
+        val projectTrackedConfigs = trackedConfigs.filter { 
+            val normalizedPath = java.nio.file.Paths.get(it).normalize().toString().replace('\\', '/')
+            normalizedPath.startsWith(workDirPath) 
+        }
+        
+        return Result.success((activeConfigs.reversed() + projectTrackedConfigs).distinct())
     }
 
     // mise exec

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/command/MiseCommandLineHelper.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/command/MiseCommandLineHelper.kt
@@ -300,24 +300,40 @@ object MiseCommandLineHelper {
         workDir: String = project.guessMiseProjectPath(),
     ): Result<List<String>> {
         val miseCommandLine = MiseCommandLine(project, workDir, configEnvironment)
-        
+
         val activeConfigs = miseCommandLine
             .runCommandLine<List<MiseConfigLsOutput>>(listOf("config", "ls", "--json"))
             .map { list -> list.map { it.path } }
             .getOrElse { emptyList() }
-            
+
         val trackedConfigs = miseCommandLine
             .runRawCommandLine(listOf("config", "--tracked-configs"))
             .map { it.lines().map { line -> line.trim() }.filter { trimmed -> trimmed.isNotEmpty() } }
             .getOrElse { emptyList() }
-            
-        val workDirPath = java.nio.file.Paths.get(workDir).normalize().toString().replace('\\', '/')
-        val projectTrackedConfigs = trackedConfigs.filter { 
-            val normalizedPath = java.nio.file.Paths.get(it).normalize().toString().replace('\\', '/')
-            normalizedPath.startsWith(workDirPath) 
+
+        return Result.success(mergeProjectConfigs(activeConfigs, trackedConfigs, workDir))
+    }
+
+    /**
+     * Merges the output of `mise config ls` and `mise config --tracked-configs`
+     * into a single deduplicated list ordered from General (global) to Specific (subdirectory).
+     *
+     * [activeConfigs] is the output of `mise config ls --json` (ordered from specific to general).
+     * [trackedConfigs] is the output of `mise config --tracked-configs` (all configs on the OS).
+     * [workDir] is the project root directory; only tracked configs under this path are included.
+     */
+    internal fun mergeProjectConfigs(
+        activeConfigs: List<String>,
+        trackedConfigs: List<String>,
+        workDir: String,
+    ): List<String> {
+        val normalizedWorkDir = Paths.get(workDir).normalize().toString().replace('\\', '/')
+        val workDirPrefix = if (normalizedWorkDir.endsWith("/")) normalizedWorkDir else "$normalizedWorkDir/"
+        val projectTrackedConfigs = trackedConfigs.filter {
+            val normalizedPath = Paths.get(it).normalize().toString().replace('\\', '/')
+            normalizedPath.startsWith(workDirPrefix) || normalizedPath == normalizedWorkDir
         }
-        
-        return Result.success((activeConfigs.reversed() + projectTrackedConfigs).distinct())
+        return (activeConfigs.reversed() + projectTrackedConfigs).distinct()
     }
 
     // mise exec

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/command/MiseCommandLineHelper.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/command/MiseCommandLineHelper.kt
@@ -301,10 +301,14 @@ object MiseCommandLineHelper {
     ): Result<List<String>> {
         val miseCommandLine = MiseCommandLine(project, workDir, configEnvironment)
 
-        val activeConfigs = miseCommandLine
-            .runCommandLine<List<MiseConfigLsOutput>>(listOf("config", "ls", "--json"))
-            .map { list -> list.map { it.path } }
-            .getOrElse { emptyList() }
+        // 1. Get active configs from current directory (sorted most specific to most general)
+        val activeConfigs = miseCommandLine.runCommandLine(
+            listOf("config", "ls", "--json"),
+            parser = { output ->
+                if (output.isBlank()) emptyList<MiseConfigLsOutput>()
+                else MiseCommandLineOutputParser.parse<List<MiseConfigLsOutput>>(output)
+            }
+        ).getOrDefault(emptyList()).map { it.path }
 
         val trackedConfigs = miseCommandLine
             .runRawCommandLine(listOf("config", "--tracked-configs"))

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/command/MiseConfigLsOutput.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/command/MiseConfigLsOutput.kt
@@ -1,0 +1,8 @@
+package com.github.l34130.mise.core.command
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MiseConfigLsOutput(
+    val path: String,
+)

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/command/MiseExecutableManager.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/command/MiseExecutableManager.kt
@@ -192,6 +192,13 @@ class MiseExecutableManager(
 
     fun getAutoDetectedExecutableInfo(): MiseExecutableInfo = getAutoDetectedInfo()
 
+    /**
+     * Returns the cached auto-detected executable info without triggering detection.
+     * Safe to call from EDT or under a read lock. Returns null if the cache is cold.
+     */
+    fun getAutoDetectedExecutableInfoIfCached(): MiseExecutableInfo? =
+        cacheService.getCachedExecutable(AUTO_DETECTED_KEY)
+
     private fun getAutoDetectedInfo(): MiseExecutableInfo {
         return cacheService.getOrComputeExecutable(AUTO_DETECTED_KEY) {
             val projectPath = project.guessMiseProjectPath()

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/lang/completion/MiseTomlTaskCompletionProvider.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/lang/completion/MiseTomlTaskCompletionProvider.kt
@@ -89,20 +89,20 @@ class MiseTomlTaskCompletionProvider : CompletionProvider<CompletionParameters>(
         }
         if (currentTaskSegment == null) return
 
-        for (task in project.service<MiseTaskResolver>().getCachedTasksOrEmptyList()) {
+        val allTasks = project.service<MiseTaskResolver>().getCachedTasksOrEmptyList()
+            .associateBy { it.name }.values
+        for (task in allTasks) {
             if (dependsArray?.elements?.any { it.stringValue == task.name } == true) continue
-            if (task.name == currentTaskSegment.name) continue
+            if (task.name == currentTaskSegment?.name) continue
 
             val psiElement =
                 when (task) {
                     is MiseShellScriptTask -> {
-                        if (!task.file.isValid) continue
-                        task.file.findPsiFile(project) ?: continue
+                        task.file.takeIf { it.isValid }?.findPsiFile(project) ?: continue
                     }
 
                     is MiseTomlTableTask -> {
-                        if (!task.keySegment.isValid) continue
-                        task.keySegment
+                        task.keySegment.takeIf { it.isValid } ?: continue
                     }
 
                     is MiseUnknownTask -> {

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/lang/resolve/MiseTomlTaskDependencyReferenceProvider.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/lang/resolve/MiseTomlTaskDependencyReferenceProvider.kt
@@ -51,19 +51,20 @@ class MiseTomlTaskDependencyReferenceProvider : PsiReferenceProvider() {
             val project = element.project
             val resolver = project.service<MiseTaskResolver>()
             val tasks = resolver.getCachedTasksOrEmptyList()
-            val result =
+            val matchedTasks =
                 if (isWildcard) {
                     // FIXME: IDK why this is not working
                     tasks.filter { it.name.startsWith(value.dropLast(1)) }
                 } else {
                     tasks.filter { it.name == value }
-                }.mapNotNull {
-                    when (it) {
-                        is MiseShellScriptTask -> it.file.findPsiFile(project)
-                        is MiseTomlTableTask -> it.keySegment
-                        is MiseUnknownTask -> null
-                    }
+                }.associateBy { it.name }.values
+            val result = matchedTasks.mapNotNull {
+                when (it) {
+                    is MiseShellScriptTask -> it.file.takeIf { f -> f.isValid }?.findPsiFile(project)
+                    is MiseTomlTableTask -> it.keySegment.takeIf { seg -> seg.isValid }
+                    is MiseUnknownTask -> null
                 }
+            }
 
             return PsiElementResolveResult.createResults(result)
         }

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/setting/MiseConfigurable.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/setting/MiseConfigurable.kt
@@ -78,10 +78,11 @@ class MiseConfigurable(
         myMiseNxCb.isSelected = projectSettings.state.useMiseInNxCommands
         myMiseAllCommandLinesCb.isSelected = projectSettings.state.useMiseInAllCommandLines
 
-        // Set placeholder text for auto-detected path
-        val autoDetectedInfo = executableManager.getAutoDetectedExecutableInfo()
-        val autoDetectedPath = autoDetectedInfo.path
-        val autoDetectedVersion = autoDetectedInfo.version?.toString()
+        // Set placeholder text for auto-detected path (non-blocking cache lookup to avoid
+        // triggering executable detection under the settings dialog's read lock)
+        val autoDetectedInfo = executableManager.getAutoDetectedExecutableInfoIfCached()
+        val autoDetectedPath = autoDetectedInfo?.path ?: "mise"
+        val autoDetectedVersion = autoDetectedInfo?.version?.toString()
         val autoDetectedLabel = if (autoDetectedVersion != null) {
             "Auto-detected: $autoDetectedPath (version: $autoDetectedVersion)"
         } else {

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/toolwindow/nodes/MiseRootNode.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/toolwindow/nodes/MiseRootNode.kt
@@ -195,13 +195,13 @@ class MiseRootNode(
             )
 
         val projectTasks: List<MiseTask> = taskResolver.getCachedTasksOrEmptyList(configEnvironment).sortedBy { it.name }
-        val trackedConfigs =
+        val activeConfigs =
             MiseCommandLineHelper
-                .getTrackedConfigs(project, configEnvironment, projectBaseDir)
-                .onFailure { MiseNotificationServiceUtils.notifyException("Failed to get tracked configs", it, project) }
+                .getProjectTrackedConfigs(project, configEnvironment, projectBaseDir)
+                .onFailure { MiseNotificationServiceUtils.notifyException("Failed to get active configs", it, project) }
                 .getOrElse { emptyList() }
         val allowedConfigDirs =
-            trackedConfigs
+            activeConfigs
                 .filter { it.endsWith(".toml") }
                 .map { PathUtil.getParentPath(it) }
                 .filter { isPathInProjectResolutionChain(projectBaseDir, it) }

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/wsl/WslPathUtils.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/wsl/WslPathUtils.kt
@@ -34,6 +34,7 @@ object WslPathUtils {
     // WslPath API handles UNC paths, but not command-line format
     // Matches: wsl.exe -d "Ubuntu 20.04" or wsl -d Ubuntu or wsl.exe -d 'Debian'
     private val WSL_COMMAND_PATTERN = Regex("""wsl(?:\.exe)?\s+-d\s+(?:"([^"]+)"|'([^']+)'|(\S+))""")
+    private val WSL_UNC_PATTERN = Regex("""^//(?:wsl\.localhost|wsl\$)/([^/]+)(?:/(.*))?$""", RegexOption.IGNORE_CASE)
 
     /**
      * Detects if the given executable path represents a WSL-based mise installation.
@@ -172,16 +173,31 @@ object WslPathUtils {
      * @return The Unix path, or null if not a valid UNC WSL path
      */
     fun convertWindowsUncToUnixPath(uncPath: String): String? {
-        // Only works on Windows where IntelliJ's WslPath API is available
-        if (!SystemInfo.isWindows) return null
         if (uncPath.isBlank()) return null
 
-        // Use IntelliJ's WslPath API for parsing
-        val wslPath = WslPath.parseWindowsUncPath(uncPath) ?: return null
-        return wslPath.linuxPath
+        if (SystemInfo.isWindows) {
+            // Use IntelliJ's WslPath API for parsing
+            WslPath.parseWindowsUncPath(uncPath)?.let { return it.linuxPath }
+        }
+
+        return parseWslUncPath(uncPath)?.linuxPath
     }
 
     fun maybeConvertWindowsUncToUnixPath(maybeUncPath: String): String = convertWindowsUncToUnixPath(maybeUncPath) ?: maybeUncPath
+
+    private data class ParsedWslUncPath(
+        val distributionId: String,
+        val linuxPath: String,
+    )
+
+    private fun parseWslUncPath(path: String): ParsedWslUncPath? {
+        val normalizedPath = path.replace('\\', '/')
+        val match = WSL_UNC_PATTERN.matchEntire(normalizedPath) ?: return null
+        val relativeLinuxPath = match.groups[2]?.value.orEmpty()
+        val linuxPath = if (relativeLinuxPath.isEmpty()) "/" else "/$relativeLinuxPath"
+
+        return ParsedWslUncPath(match.groupValues[1], linuxPath)
+    }
 
     private data class NormalizedPath(
         val distroId: String?,
@@ -189,9 +205,15 @@ object WslPathUtils {
     )
 
     private fun normalizeForComparison(path: String): NormalizedPath {
-        val wsl = WslPath.parseWindowsUncPath(path)
-        if (wsl != null) {
-            return NormalizedPath(wsl.distributionId.uppercase(Locale.ROOT), FileUtil.toSystemIndependentName(wsl.linuxPath))
+        if (SystemInfo.isWindows) {
+            val wsl = WslPath.parseWindowsUncPath(path)
+            if (wsl != null) {
+                return NormalizedPath(wsl.distributionId.uppercase(Locale.ROOT), FileUtil.toSystemIndependentName(wsl.linuxPath))
+            }
+        }
+
+        parseWslUncPath(path)?.let {
+            return NormalizedPath(it.distributionId.uppercase(Locale.ROOT), FileUtil.toSystemIndependentName(it.linuxPath))
         }
 
         return NormalizedPath(null, FileUtil.toSystemIndependentName(path))

--- a/modules/core/src/test/kotlin/com/github/l34130/mise/core/MiseConfigFileResolverTest.kt
+++ b/modules/core/src/test/kotlin/com/github/l34130/mise/core/MiseConfigFileResolverTest.kt
@@ -108,15 +108,26 @@ class MiseConfigFileResolverTest : BasePlatformTestCase() {
         val configs =
             withCommandLineExecutor(
                 executor = { commandLine, _ ->
-                    val isTrackedConfigs = commandLine.commandLineString.contains("config --tracked-configs")
-                    if (isTrackedConfigs) {
-                        processOutput(
-                            stdout =
-                                listOf(parentToml, childToml)
-                                    .joinToString("\n") { it.toString().replace('\\', '/') } + "\n",
-                        )
-                    } else {
-                        processOutput()
+                    val cmdStr = commandLine.commandLineString
+                    when {
+                        cmdStr.contains("config ls --json") -> {
+                            // mise config ls --json returns active configs (specific to general)
+                            val json = """
+                                [
+                                  {"path": "${childToml.toString().replace('\\', '/')}"},
+                                  {"path": "${parentToml.toString().replace('\\', '/')}"}
+                                ]
+                            """.trimIndent()
+                            processOutput(stdout = json)
+                        }
+                        cmdStr.contains("config --tracked-configs") -> {
+                            processOutput(
+                                stdout =
+                                    listOf(parentToml, childToml)
+                                        .joinToString("\n") { it.toString().replace('\\', '/') } + "\n",
+                            )
+                        }
+                        else -> processOutput()
                     }
                 },
             ) {

--- a/modules/core/src/test/kotlin/com/github/l34130/mise/core/command/MiseBinaryFixture.kt
+++ b/modules/core/src/test/kotlin/com/github/l34130/mise/core/command/MiseBinaryFixture.kt
@@ -1,0 +1,72 @@
+package com.github.l34130.mise.core.command
+
+import java.io.File
+import java.net.URI
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.attribute.PosixFilePermissions
+
+/**
+ * Downloads and caches real mise binaries from GitHub Releases for integration tests.
+ * Binaries are cached in a shared temp directory to avoid re-downloading across test runs.
+ */
+object MiseBinaryFixture {
+    private val cacheDir: Path by lazy {
+        val dir = Path.of(System.getProperty("java.io.tmpdir"), "mise-test-binaries")
+        Files.createDirectories(dir)
+        dir
+    }
+
+    /**
+     * Returns the path to a mise binary for the given version.
+     * Downloads it from GitHub Releases if not already cached.
+     */
+    fun getBinary(version: String): Path {
+        val binaryName = buildAssetName(version)
+        val cachedBinary = cacheDir.resolve(binaryName)
+
+        if (Files.exists(cachedBinary) && Files.size(cachedBinary) > 0) {
+            return cachedBinary
+        }
+
+        val url = "https://github.com/jdx/mise/releases/download/v$version/$binaryName"
+        downloadFile(url, cachedBinary)
+        makeExecutable(cachedBinary)
+        return cachedBinary
+    }
+
+    private fun buildAssetName(version: String): String {
+        val os = System.getProperty("os.name").lowercase()
+        val arch = System.getProperty("os.arch").lowercase()
+
+        val platform = when {
+            os.contains("mac") || os.contains("darwin") -> "macos"
+            os.contains("linux") -> "linux"
+            os.contains("windows") -> "windows"
+            else -> error("Unsupported OS: $os")
+        }
+
+        val architecture = when {
+            arch == "aarch64" || arch == "arm64" -> "arm64"
+            arch == "amd64" || arch == "x86_64" -> "x64"
+            else -> error("Unsupported architecture: $arch")
+        }
+
+        return "mise-v$version-$platform-$architecture"
+    }
+
+    private fun downloadFile(url: String, target: Path) {
+        URI(url).toURL().openStream().use { input ->
+            Files.newOutputStream(target).use { output ->
+                input.copyTo(output)
+            }
+        }
+    }
+
+    private fun makeExecutable(path: Path) {
+        val os = System.getProperty("os.name").lowercase()
+        if (!os.contains("windows")) {
+            Files.setPosixFilePermissions(path, PosixFilePermissions.fromString("rwxr-xr-x"))
+        }
+    }
+}

--- a/modules/core/src/test/kotlin/com/github/l34130/mise/core/command/MiseCommandLineHelperProjectConfigsTest.kt
+++ b/modules/core/src/test/kotlin/com/github/l34130/mise/core/command/MiseCommandLineHelperProjectConfigsTest.kt
@@ -196,4 +196,32 @@ class MiseCommandLineHelperProjectConfigsTest {
             result,
         )
     }
+
+    @Test
+    fun `mergeProjectConfigs keeps WSL tracked configs under UNC workDir`() {
+        val activeConfigs = listOf(
+            "/home/me/app/mise.toml",
+            "/home/me/.config/mise/config.toml",
+        )
+        val trackedConfigs = listOf(
+            "/home/me/app/mise.toml",
+            "/home/me/app/sub/mise.toml",
+            "/home/me/other/mise.toml",
+        )
+
+        val result = MiseCommandLineHelper.mergeProjectConfigs(
+            activeConfigs = activeConfigs,
+            trackedConfigs = trackedConfigs,
+            workDir = "//wsl.localhost/Ubuntu/home/me/app",
+        )
+
+        assertEquals(
+            listOf(
+                "/home/me/.config/mise/config.toml",
+                "/home/me/app/mise.toml",
+                "/home/me/app/sub/mise.toml",
+            ),
+            result,
+        )
+    }
 }

--- a/modules/core/src/test/kotlin/com/github/l34130/mise/core/command/MiseCommandLineHelperProjectConfigsTest.kt
+++ b/modules/core/src/test/kotlin/com/github/l34130/mise/core/command/MiseCommandLineHelperProjectConfigsTest.kt
@@ -1,0 +1,199 @@
+package com.github.l34130.mise.core.command
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class MiseCommandLineHelperProjectConfigsTest {
+
+    @Test
+    fun `mergeProjectConfigs filters out unrelated project configs`() {
+        val activeConfigs = listOf(
+            "/home/user/workspace/my-project/mise.toml",
+            "/home/user/.config/mise/config.toml",
+        )
+        val trackedConfigs = listOf(
+            "/home/user/workspace/my-project/mise.toml",
+            "/home/user/workspace/my-project/server/mise.toml",
+            "/home/user/workspace/other-project/mise.toml",
+            "/home/user/.config/mise/config.toml",
+        )
+
+        val result = MiseCommandLineHelper.mergeProjectConfigs(
+            activeConfigs = activeConfigs,
+            trackedConfigs = trackedConfigs,
+            workDir = "/home/user/workspace/my-project",
+        )
+
+        assertEquals(
+            listOf(
+                "/home/user/.config/mise/config.toml",
+                "/home/user/workspace/my-project/mise.toml",
+                "/home/user/workspace/my-project/server/mise.toml",
+            ),
+            result,
+        )
+    }
+
+    @Test
+    fun `mergeProjectConfigs orders from general to specific`() {
+        val activeConfigs = listOf(
+            "/home/user/workspace/project/mise.toml",
+            "/home/user/.config/mise/config.toml",
+        )
+        val trackedConfigs = listOf(
+            "/home/user/workspace/project/mise.toml",
+        )
+
+        val result = MiseCommandLineHelper.mergeProjectConfigs(
+            activeConfigs = activeConfigs,
+            trackedConfigs = trackedConfigs,
+            workDir = "/home/user/workspace/project",
+        )
+
+        // Global config should come first, project root second
+        assertEquals("/home/user/.config/mise/config.toml", result[0])
+        assertEquals("/home/user/workspace/project/mise.toml", result[1])
+    }
+
+    @Test
+    fun `mergeProjectConfigs deduplicates paths`() {
+        val activeConfigs = listOf(
+            "/home/user/workspace/project/mise.toml",
+            "/home/user/.config/mise/config.toml",
+        )
+        val trackedConfigs = listOf(
+            "/home/user/workspace/project/mise.toml",
+            "/home/user/workspace/project/sub/mise.toml",
+        )
+
+        val result = MiseCommandLineHelper.mergeProjectConfigs(
+            activeConfigs = activeConfigs,
+            trackedConfigs = trackedConfigs,
+            workDir = "/home/user/workspace/project",
+        )
+
+        // mise.toml appears in both activeConfigs and trackedConfigs but should appear only once
+        assertEquals(3, result.size)
+        assertEquals(
+            listOf(
+                "/home/user/.config/mise/config.toml",
+                "/home/user/workspace/project/mise.toml",
+                "/home/user/workspace/project/sub/mise.toml",
+            ),
+            result,
+        )
+    }
+
+    @Test
+    fun `mergeProjectConfigs handles empty activeConfigs`() {
+        val trackedConfigs = listOf(
+            "/home/user/workspace/project/mise.toml",
+            "/home/user/workspace/other/mise.toml",
+        )
+
+        val result = MiseCommandLineHelper.mergeProjectConfigs(
+            activeConfigs = emptyList(),
+            trackedConfigs = trackedConfigs,
+            workDir = "/home/user/workspace/project",
+        )
+
+        assertEquals(listOf("/home/user/workspace/project/mise.toml"), result)
+    }
+
+    @Test
+    fun `mergeProjectConfigs handles empty trackedConfigs`() {
+        val activeConfigs = listOf(
+            "/home/user/workspace/project/mise.toml",
+            "/home/user/.config/mise/config.toml",
+        )
+
+        val result = MiseCommandLineHelper.mergeProjectConfigs(
+            activeConfigs = activeConfigs,
+            trackedConfigs = emptyList(),
+            workDir = "/home/user/workspace/project",
+        )
+
+        assertEquals(
+            listOf(
+                "/home/user/.config/mise/config.toml",
+                "/home/user/workspace/project/mise.toml",
+            ),
+            result,
+        )
+    }
+
+    @Test
+    fun `mergeProjectConfigs handles both empty`() {
+        val result = MiseCommandLineHelper.mergeProjectConfigs(
+            activeConfigs = emptyList(),
+            trackedConfigs = emptyList(),
+            workDir = "/home/user/workspace/project",
+        )
+
+        assertEquals(emptyList<String>(), result)
+    }
+
+    @Test
+    fun `mergeProjectConfigs filters multiple unrelated projects`() {
+        val activeConfigs = listOf(
+            "/home/user/workspace/intellij-mise/mise.toml",
+            "/home/user/.config/mise/config.toml",
+        )
+        val trackedConfigs = listOf(
+            "/home/user/workspace/intellij-mise/mise.toml",
+            "/home/user/workspace/intellij-mise/modules/core/mise.toml",
+            "/home/user/workspace/gang-e-nae/mise.toml",
+            "/home/user/workspace/gang-e-nae/backend/mise.toml",
+            "/home/user/workspace/another-project/mise.toml",
+            "/home/user/.config/mise/config.toml",
+        )
+
+        val result = MiseCommandLineHelper.mergeProjectConfigs(
+            activeConfigs = activeConfigs,
+            trackedConfigs = trackedConfigs,
+            workDir = "/home/user/workspace/intellij-mise",
+        )
+
+        // Only global config + intellij-mise configs should be present
+        assertEquals(
+            listOf(
+                "/home/user/.config/mise/config.toml",
+                "/home/user/workspace/intellij-mise/mise.toml",
+                "/home/user/workspace/intellij-mise/modules/core/mise.toml",
+            ),
+            result,
+        )
+    }
+
+    @Test
+    fun `mergeProjectConfigs does not include project with similar prefix`() {
+        val activeConfigs = listOf(
+            "/home/user/workspace/app/mise.toml",
+            "/home/user/.config/mise/config.toml",
+        )
+        val trackedConfigs = listOf(
+            "/home/user/workspace/app/mise.toml",
+            "/home/user/workspace/app-other/mise.toml",
+            "/home/user/workspace/application/mise.toml",
+        )
+
+        val result = MiseCommandLineHelper.mergeProjectConfigs(
+            activeConfigs = activeConfigs,
+            trackedConfigs = trackedConfigs,
+            workDir = "/home/user/workspace/app",
+        )
+
+        // "app-other" and "application" should NOT be included even though they start with "app"
+        // because path normalization uses full path segments
+        assertEquals(
+            listOf(
+                "/home/user/.config/mise/config.toml",
+                "/home/user/workspace/app/mise.toml",
+            ),
+            result,
+        )
+    }
+}

--- a/modules/core/src/test/kotlin/com/github/l34130/mise/core/command/MiseProjectConfigsIntegrationTest.kt
+++ b/modules/core/src/test/kotlin/com/github/l34130/mise/core/command/MiseProjectConfigsIntegrationTest.kt
@@ -1,0 +1,198 @@
+package com.github.l34130.mise.core.command
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.writeText
+
+/**
+ * Integration tests that download a real mise binary and validate
+ * actual CLI output for `config ls --json` and `config --tracked-configs`.
+ *
+ * These tests verify the real-world behavior of mise commands
+ * that [MiseCommandLineHelper.getProjectTrackedConfigs] depends on.
+ */
+@RunWith(JUnit4::class)
+class MiseProjectConfigsIntegrationTest {
+    private lateinit var miseBinary: Path
+
+    @Before
+    fun setUp() {
+        // Skip tests if we can't determine the platform
+        val os = System.getProperty("os.name").lowercase()
+        val arch = System.getProperty("os.arch").lowercase()
+        assumeTrue(
+            "Skipping on unsupported platform: $os/$arch",
+            (os.contains("mac") || os.contains("linux")) &&
+                (arch == "aarch64" || arch == "arm64" || arch == "amd64" || arch == "x86_64"),
+        )
+
+        miseBinary = MiseBinaryFixture.getBinary(MISE_VERSION)
+        assumeTrue("Mise binary should exist", Files.exists(miseBinary))
+    }
+
+    private fun runMise(
+        vararg args: String,
+        workDir: Path,
+        env: Map<String, String> = emptyMap(),
+    ): String {
+        // Automatically trust the workDir to avoid prompt errors
+        val trustProcess = ProcessBuilder(miseBinary.toString(), "trust", ".")
+            .directory(workDir.toFile())
+            .redirectErrorStream(true)
+            .also { pb ->
+                pb.environment().putAll(env)
+                pb.environment()["MISE_GLOBAL_CONFIG_FILE"] = "/dev/null"
+                pb.environment()["MISE_CONFIG_DIR"] = "/dev/null"
+                pb.environment()["MISE_DATA_DIR"] = workDir.resolve(".mise-data").toString()
+            }.start()
+        trustProcess.waitFor()
+
+        val process =
+            ProcessBuilder(miseBinary.toString(), *args)
+                .directory(workDir.toFile())
+                .redirectErrorStream(false)
+                .also { pb ->
+                    pb.environment().putAll(env)
+                    // Disable mise's global config to avoid pollution from the host machine
+                    pb.environment()["MISE_GLOBAL_CONFIG_FILE"] = "/dev/null"
+                    pb.environment()["MISE_CONFIG_DIR"] = "/dev/null"
+                    pb.environment()["MISE_DATA_DIR"] = workDir.resolve(".mise-data").toString()
+                }.start()
+
+        val stdout = process.inputStream.bufferedReader().readText()
+        val exitCode = process.waitFor()
+        check(exitCode == 0) {
+            val stderr = process.errorStream.bufferedReader().readText()
+            "mise ${args.joinToString(" ")} exited with code $exitCode.\nstderr: $stderr\nstdout: $stdout"
+        }
+        return stdout
+    }
+
+    @Test
+    fun `config ls --json returns only active configs for current directory`() {
+        val rootDir = Files.createTempDirectory("mise-integration-config-ls")
+        val projectDir = rootDir.resolve("my-project").createDirectories()
+        projectDir.resolve("mise.toml").writeText("[tools]\nnode = '22'\n")
+
+        val otherDir = rootDir.resolve("other-project").createDirectories()
+        otherDir.resolve("mise.toml").writeText("[tools]\npython = '3.12'\n")
+
+        val output = runMise("config", "ls", "--json", workDir = projectDir)
+        val parsed: List<MiseConfigLsOutput> = MiseCommandLineOutputParser.parse(output)
+        val paths = parsed.map { it.path }
+
+        assertTrue(
+            "Should include project mise.toml",
+            paths.any { it.contains("my-project/mise.toml") },
+        )
+        assertFalse(
+            "Should NOT include other-project mise.toml",
+            paths.any { it.contains("other-project/mise.toml") },
+        )
+    }
+
+    @Test
+    fun `config --tracked-configs returns configs from current directory`() {
+        val rootDir = Files.createTempDirectory("mise-integration-tracked")
+        val projectDir = rootDir.resolve("my-project").createDirectories()
+        projectDir.resolve("mise.toml").writeText("[tools]\nnode = '22'\n")
+
+        val output = runMise("config", "--tracked-configs", workDir = projectDir)
+        val paths = output.lines().map { it.trim() }.filter { it.isNotEmpty() }
+
+        assertTrue(
+            "Should include project mise.toml",
+            paths.any { it.contains("my-project/mise.toml") },
+        )
+    }
+
+    @Test
+    fun `mergeProjectConfigs with real CLI output excludes unrelated projects`() {
+        val rootDir = Files.createTempDirectory("mise-integration-merge")
+        val projectDir = rootDir.resolve("my-project").createDirectories()
+        projectDir.resolve("mise.toml").writeText("[tools]\nnode = '22'\n")
+
+        val otherDir = rootDir.resolve("other-project").createDirectories()
+        otherDir.resolve("mise.toml").writeText("[tools]\npython = '3.12'\n")
+
+        // Get real output from both commands
+        val configLsOutput = runMise("config", "ls", "--json", workDir = projectDir)
+        val activeConfigs: List<String> =
+            MiseCommandLineOutputParser.parse<List<MiseConfigLsOutput>>(configLsOutput).map { it.path }
+
+        val trackedOutput = runMise("config", "--tracked-configs", workDir = projectDir)
+        val trackedConfigs = trackedOutput.lines().map { it.trim() }.filter { it.isNotEmpty() }
+
+        // Now also run tracked-configs from the other project to simulate OS-wide results
+        val otherTrackedOutput = runMise("config", "--tracked-configs", workDir = otherDir)
+        val otherTrackedConfigs = otherTrackedOutput.lines().map { it.trim() }.filter { it.isNotEmpty() }
+        val allTrackedConfigs = (trackedConfigs + otherTrackedConfigs).distinct()
+
+        // Apply our mergeProjectConfigs logic
+        val result = MiseCommandLineHelper.mergeProjectConfigs(
+            activeConfigs = activeConfigs,
+            trackedConfigs = allTrackedConfigs,
+            workDir = projectDir.toString(),
+        )
+
+        assertTrue(
+            "Should include project mise.toml",
+            result.any { it.contains("my-project/mise.toml") },
+        )
+        assertFalse(
+            "Should NOT include other-project mise.toml",
+            result.any { it.contains("other-project/mise.toml") },
+        )
+    }
+
+    @Test
+    fun `config ls --json output is parseable by MiseConfigLsOutput`() {
+        val rootDir = Files.createTempDirectory("mise-integration-parse")
+        rootDir.resolve("mise.toml").writeText("[tools]\nnode = '22'\n")
+
+        val output = runMise("config", "ls", "--json", workDir = rootDir)
+        val parsed: List<MiseConfigLsOutput> = MiseCommandLineOutputParser.parse(output)
+
+        assertTrue("Should parse at least one config", parsed.isNotEmpty())
+        assertTrue(
+            "Should contain the project mise.toml",
+            parsed.any { it.path.endsWith("mise.toml") },
+        )
+    }
+
+    @Test
+    fun `config ls --json returns configs ordered from specific to general`() {
+        val rootDir = Files.createTempDirectory("mise-integration-order")
+        val projectDir = rootDir.resolve("project").createDirectories()
+        projectDir.resolve("mise.toml").writeText("[tools]\nnode = '22'\n")
+
+        val output = runMise("config", "ls", "--json", workDir = projectDir)
+        val parsed: List<MiseConfigLsOutput> = MiseCommandLineOutputParser.parse(output)
+        val paths = parsed.map { it.path }
+
+        // The first entry should be the most specific (project-level)
+        if (paths.isNotEmpty()) {
+            assertTrue(
+                "First config should be the project mise.toml",
+                paths.first().contains("project/mise.toml"),
+            )
+        }
+    }
+
+    companion object {
+        /**
+         * The mise version to use for integration tests.
+         * This should be updated when new mise features are needed.
+         */
+        private const val MISE_VERSION = "2025.11.1"
+    }
+}

--- a/modules/core/src/test/kotlin/com/github/l34130/mise/core/command/MiseProjectConfigsIntegrationTest.kt
+++ b/modules/core/src/test/kotlin/com/github/l34130/mise/core/command/MiseProjectConfigsIntegrationTest.kt
@@ -44,29 +44,22 @@ class MiseProjectConfigsIntegrationTest {
         workDir: Path,
         env: Map<String, String> = emptyMap(),
     ): String {
+        val miseEnv = isolatedMiseEnv(workDir) + env
+
         // Automatically trust the workDir to avoid prompt errors
         val trustProcess = ProcessBuilder(miseBinary.toString(), "trust", ".")
             .directory(workDir.toFile())
             .redirectErrorStream(true)
-            .also { pb ->
-                pb.environment().putAll(env)
-                pb.environment()["MISE_GLOBAL_CONFIG_FILE"] = "/dev/null"
-                pb.environment()["MISE_CONFIG_DIR"] = "/dev/null"
-                pb.environment()["MISE_DATA_DIR"] = workDir.resolve(".mise-data").toString()
-            }.start()
+            .also { pb -> configureMiseEnvironment(pb, miseEnv) }
+            .start()
         trustProcess.waitFor()
 
         val process =
             ProcessBuilder(miseBinary.toString(), *args)
                 .directory(workDir.toFile())
                 .redirectErrorStream(false)
-                .also { pb ->
-                    pb.environment().putAll(env)
-                    // Disable mise's global config to avoid pollution from the host machine
-                    pb.environment()["MISE_GLOBAL_CONFIG_FILE"] = "/dev/null"
-                    pb.environment()["MISE_CONFIG_DIR"] = "/dev/null"
-                    pb.environment()["MISE_DATA_DIR"] = workDir.resolve(".mise-data").toString()
-                }.start()
+                .also { pb -> configureMiseEnvironment(pb, miseEnv) }
+                .start()
 
         val stdout = process.inputStream.bufferedReader().readText()
         val exitCode = process.waitFor()
@@ -75,6 +68,36 @@ class MiseProjectConfigsIntegrationTest {
             "mise ${args.joinToString(" ")} exited with code $exitCode.\nstderr: $stderr\nstdout: $stdout"
         }
         return stdout
+    }
+
+    private fun configureMiseEnvironment(processBuilder: ProcessBuilder, env: Map<String, String>) {
+        val processEnv = processBuilder.environment()
+        processEnv.keys.removeIf { it.startsWith("MISE_") }
+        processEnv.putAll(env)
+    }
+
+    private fun isolatedMiseEnv(workDir: Path): Map<String, String> {
+        val rootDir = workDir.resolve(".mise-test-state").createDirectories()
+        val configDir = rootDir.resolve("config").createDirectories()
+        val dataDir = rootDir.resolve("data").createDirectories()
+        val stateDir = rootDir.resolve("state").createDirectories()
+        val cacheDir = rootDir.resolve("cache").createDirectories()
+        val homeDir = rootDir.resolve("home").createDirectories()
+        val globalConfigFile = configDir.resolve("config.toml")
+        globalConfigFile.writeText("")
+
+        return mapOf(
+            "HOME" to homeDir.toString(),
+            "XDG_CONFIG_HOME" to configDir.toString(),
+            "XDG_DATA_HOME" to dataDir.toString(),
+            "XDG_STATE_HOME" to stateDir.toString(),
+            "XDG_CACHE_HOME" to cacheDir.toString(),
+            "MISE_GLOBAL_CONFIG_FILE" to globalConfigFile.toString(),
+            "MISE_CONFIG_DIR" to configDir.resolve("mise").createDirectories().toString(),
+            "MISE_DATA_DIR" to dataDir.resolve("mise").createDirectories().toString(),
+            "MISE_STATE_DIR" to stateDir.resolve("mise").createDirectories().toString(),
+            "MISE_CACHE_DIR" to cacheDir.resolve("mise").createDirectories().toString(),
+        )
     }
 
     @Test
@@ -106,6 +129,7 @@ class MiseProjectConfigsIntegrationTest {
         val projectDir = rootDir.resolve("my-project").createDirectories()
         projectDir.resolve("mise.toml").writeText("[tools]\nnode = '22'\n")
 
+        runMise("config", "ls", "--json", workDir = projectDir)
         val output = runMise("config", "--tracked-configs", workDir = projectDir)
         val paths = output.lines().map { it.trim() }.filter { it.isNotEmpty() }
 
@@ -133,6 +157,7 @@ class MiseProjectConfigsIntegrationTest {
         val trackedConfigs = trackedOutput.lines().map { it.trim() }.filter { it.isNotEmpty() }
 
         // Now also run tracked-configs from the other project to simulate OS-wide results
+        runMise("config", "ls", "--json", workDir = otherDir)
         val otherTrackedOutput = runMise("config", "--tracked-configs", workDir = otherDir)
         val otherTrackedConfigs = otherTrackedOutput.lines().map { it.trim() }.filter { it.isNotEmpty() }
         val allTrackedConfigs = (trackedConfigs + otherTrackedConfigs).distinct()


### PR DESCRIPTION
This PR addresses issue #494 ("showing unrelated projects for depends") while maintaining full support for subdirectory configurations introduced in PR #418.

### The Problem
PR #418 started using `mise config --tracked-configs` to discover subdirectory and `.env` configs. However, `--tracked-configs` returns ALL configs on the entire OS, bringing unrelated projects into the task cache and auto-complete.

### The Solution
1. `MiseCommandLineHelper` now provides `getProjectTrackedConfigs` which merges the results of:
   - `mise config ls --json` (gets active global and project-root configs)
   - `mise config --tracked-configs` **filtered by `projectBasePath`** (safely gets subdirectory configs without polluting the cache with unrelated projects).
2. The UI blocking fix from PR #495 (`getAutoDetectedExecutableInfoIfCached`) has been implemented to resolve freezing in `MiseConfigurable`.
3. Task deduplication (`.associateBy { it.name }.values`) handles situations where project tasks override global tasks perfectly.
4. The brittle `sameFile` filter from PR #495 has been discarded, fully restoring wildcard dependency support across subdirectory configurations.

Fixes #494
Replaces #495
