### PR TITLE
feat: add Maven home auto-sync from mise configuration

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -15,6 +15,7 @@
             <option value="$PROJECT_DIR$/modules/products/goland" />
             <option value="$PROJECT_DIR$/modules/products/gradle" />
             <option value="$PROJECT_DIR$/modules/products/idea" />
+            <option value="$PROJECT_DIR$/modules/products/maven" />
             <option value="$PROJECT_DIR$/modules/products/nodejs" />
             <option value="$PROJECT_DIR$/modules/products/nx" />
             <option value="$PROJECT_DIR$/modules/products/pycharm" />

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,6 +57,7 @@ dependencies {
         pluginComposedModule(implementation(project(":mise-products-diagram")))
         pluginComposedModule(implementation(project(":mise-products-goland")))
         pluginComposedModule(implementation(project(":mise-products-idea")))
+        pluginComposedModule(implementation(project(":mise-products-maven")))
         pluginComposedModule(implementation(project(":mise-products-nodejs")))
         pluginComposedModule(implementation(project(":mise-products-nx")))
         pluginComposedModule(implementation(project(":mise-products-pycharm")))
@@ -208,6 +209,7 @@ fun IntelliJPlatformPluginsExtension.configureIdeaRunIdePlugins() {
     compatiblePlugin("org.jetbrains.plugins.ruby")  // Ruby support (mise-ruby.xml)
     bundledPlugin("com.intellij.database")       // Database support (mise-database.xml)
     compatiblePlugin("com.intellij.gradle")         // Gradle tool window scenarios
+    bundledPlugin("org.jetbrains.idea.maven")    // Maven support (mise-maven.xml)
     compatiblePlugin("com.jetbrains.sh")            // Shell script support (mise-sh.xml)
     // Causes constant errors in WSL projects.
     //compatiblePlugin("dev.nx.console")              // NX Console support (mise-nx.xml)

--- a/modules/products/maven/build.gradle.kts
+++ b/modules/products/maven/build.gradle.kts
@@ -1,0 +1,29 @@
+import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
+import org.jetbrains.intellij.platform.gradle.TestFrameworkType
+
+fun properties(key: String) = project.findProperty(key).toString()
+
+plugins {
+    id("org.jetbrains.intellij.platform.module")
+    alias(libs.plugins.kotlin) // Kotlin support
+}
+
+dependencies {
+    implementation(project(":mise-core"))
+    testImplementation(libs.junit)
+
+    // Configure Gradle IntelliJ Plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
+    intellijPlatform {
+        create(
+            IntelliJPlatformType.IntellijIdeaCommunity,
+            properties("platformVersion")
+        ) { useInstaller = false }
+
+        bundledPlugin("org.jetbrains.idea.maven")
+
+        jetbrainsRuntime()
+
+        testFramework(TestFrameworkType.Platform)
+        testImplementation("org.opentest4j:opentest4j:1.3.0")
+    }
+}

--- a/modules/products/maven/src/main/kotlin/com/github/l34130/mise/maven/MiseProjectMavenSetup.kt
+++ b/modules/products/maven/src/main/kotlin/com/github/l34130/mise/maven/MiseProjectMavenSetup.kt
@@ -1,0 +1,96 @@
+package com.github.l34130.mise.maven
+
+import com.github.l34130.mise.core.command.MiseDevTool
+import com.github.l34130.mise.core.command.MiseDevToolName
+import com.github.l34130.mise.core.setup.AbstractProjectSdkSetup
+import com.intellij.openapi.options.Configurable
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.io.FileUtil
+import org.jetbrains.idea.maven.project.MavenHomeType
+import org.jetbrains.idea.maven.project.MavenInSpecificPath
+import org.jetbrains.idea.maven.project.MavenProjectsManager
+import org.jetbrains.idea.maven.project.StaticResolvedMavenHomeType
+import org.jetbrains.idea.maven.utils.MavenUtil
+import java.io.File
+import java.nio.file.Path
+import kotlin.reflect.KClass
+
+class MiseProjectMavenSetup : AbstractProjectSdkSetup() {
+    override fun getDevToolName(project: Project) = MiseDevToolName("maven")
+
+    override fun checkSdkStatus(
+        tool: MiseDevTool,
+        project: Project,
+    ): SdkStatus {
+        val mavenProjectsManager = MavenProjectsManager.getInstance(project)
+        val mavenHomeType: MavenHomeType = mavenProjectsManager.generalSettings.mavenHomeType
+        val resolvedInstallPath = resolveMavenHome(tool.resolvedInstallPath)
+
+        val currentSdkVersion = when (mavenHomeType) {
+            is MavenInSpecificPath -> {
+                if (isSamePath(mavenHomeType.mavenHome, resolvedInstallPath)) {
+                    return SdkStatus.UpToDate
+                }
+                MavenUtil.getMavenVersion(mavenHomeType) ?: mavenHomeType.title
+            }
+
+            // Bundled Maven
+            is StaticResolvedMavenHomeType -> MavenUtil.getMavenVersion(mavenHomeType) ?: mavenHomeType.title
+
+            // Maven Wrapper
+            else -> mavenHomeType.title
+        }
+
+        return SdkStatus.NeedsUpdate(
+            currentSdkVersion = currentSdkVersion,
+            requestedInstallPath = resolvedInstallPath,
+        )
+    }
+
+    override fun applySdkConfiguration(
+        tool: MiseDevTool,
+        project: Project,
+    ): ApplySdkResult {
+        val mavenProjectsManager = MavenProjectsManager.getInstance(project)
+        val mavenHome = resolveMavenHome(tool.resolvedInstallPath)
+        val homeType = MavenInSpecificPath(mavenHome)
+        mavenProjectsManager.generalSettings.mavenHomeType = homeType
+
+        return ApplySdkResult(
+            sdkName = "Maven",
+            sdkVersion = MavenUtil.getMavenVersion(homeType) ?: tool.displayVersion,
+            sdkPath = mavenHome,
+        )
+    }
+
+    override fun <T : Configurable> getConfigurableClass(): KClass<out T>? = null
+
+    /**
+     * Resolves the actual Maven home directory from a mise install path.
+     *
+     * Mise extracts the official Apache Maven tarball into a version directory,
+     * which itself contains a single subdirectory named after the distribution:
+     *
+     * ```
+     * ~/.local/share/mise/installs/maven/3.9.11/
+     * └── apache-maven-3.9.11/   ← actual Maven home
+     *     ├── bin/mvn
+     *     ├── bin/m2.conf
+     *     └── lib/maven-core-3.9.11.jar
+     * ```
+     *
+     * IntelliJ's [MavenUtil.isValidMavenHome] expects the inner directory, not the
+     * mise version root. If the given path is not a valid Maven home, this function
+     * looks one level deeper for a subdirectory that is.
+     */
+    private fun resolveMavenHome(installPath: String): String {
+        if (MavenUtil.isValidMavenHome(Path.of(installPath))) return installPath
+        return File(installPath).listFiles()
+            ?.firstOrNull { MavenUtil.isValidMavenHome(it.toPath()) }
+            ?.absolutePath
+            ?: installPath
+    }
+
+    private fun isSamePath(path1: String, path2: String): Boolean =
+        FileUtil.filesEqual(File(path1), File(path2))
+}

--- a/modules/products/maven/src/test/kotlin/com/github/l34130/mise/maven/MavenTest.kt
+++ b/modules/products/maven/src/test/kotlin/com/github/l34130/mise/maven/MavenTest.kt
@@ -1,0 +1,12 @@
+package com.github.l34130.mise.maven
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import org.jetbrains.idea.maven.project.MavenInSpecificPath
+
+class MavenTest : BasePlatformTestCase() {
+    fun `test MavenInSpecificPath stores and returns home path`() {
+        val path = "/fake/maven/3.9.6"
+        val homeType = MavenInSpecificPath(path)
+        assertEquals(path, homeType.mavenHome)
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,6 +23,7 @@ include(
     "modules/products/diagram",
     "modules/products/goland",
     "modules/products/idea",
+    "modules/products/maven",
     "modules/products/nodejs",
     "modules/products/nx",
     "modules/products/pycharm",

--- a/src/main/resources/META-INF/mise-maven.xml
+++ b/src/main/resources/META-INF/mise-maven.xml
@@ -1,0 +1,14 @@
+<idea-plugin require-restart="false">
+    <extensions defaultExtensionNs="com.intellij">
+        <postStartupActivity implementation="com.github.l34130.mise.maven.MiseProjectMavenSetup"/>
+    </extensions>
+
+    <actions>
+        <action id="com.github.l34130.mise.maven.MiseProjectMavenSetup"
+                class="com.github.l34130.mise.maven.MiseProjectMavenSetup"
+                text="Reload Maven"
+        >
+            <add-to-group group-id="com.github.l34130.mise.actions"/>
+        </action>
+    </actions>
+</idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -76,6 +76,7 @@
     <depends optional="true" config-file="mise-diagram.xml">com.intellij.diagram</depends>
     <depends optional="true" config-file="mise-goland.xml">org.jetbrains.plugins.go</depends>
     <depends optional="true" config-file="mise-idea.xml">com.intellij.java</depends>
+    <depends optional="true" config-file="mise-maven.xml">org.jetbrains.idea.maven</depends>
     <depends optional="true" config-file="mise-nodejs.xml">NodeJS</depends>
     <depends optional="true" config-file="mise-deno.xml">deno</depends>
     <depends optional="true" config-file="mise-nx.xml">dev.nx.console</depends>


### PR DESCRIPTION
Hello, thanks for the plugin, it is really useful! (: Here is a PR to add support for Maven build tool.

## Summary

Adds support for syncing the Maven home setting from the project's `mise.toml`, mirroring the existing behavior for JDK, Node.js, Ruby, etc.

## Implementation notes

mise installs Maven with the distribution tarball extracted into a subdirectory inside the version root:

```
~/.local/share/mise/installs/maven/3.9.11/
└── apache-maven-3.9.11/   ← actual Maven home
```

IntelliJ's `MavenUtil.isValidMavenHome` expects the inner directory, so the setup resolves one level deeper when the version root itself is not a valid Maven home.

## Screenshots

Maven settings:
<img width="1106" height="733" alt="maven" src="https://github.com/user-attachments/assets/e9014b0c-f7fd-4bc4-9494-ca4261ecbc2f" />

Tool reload:
<img width="446" height="322" alt="reload" src="https://github.com/user-attachments/assets/4a505289-e698-4e76-8ca0-4301291083e6" />

Sync notification:
<img width="490" height="196" alt="sync" src="https://github.com/user-attachments/assets/146344a4-a016-43a2-9f12-5b32efc8e0f0" />

## Testing

Tested on IntelliJ IDEA Community 2025.1 and Ultimate 2026.1.2.