### PR TITLE
Use explicit CLion bundled modules in CLion module Gradle config

### DIFF
--- a/modules/products/clion/build.gradle.kts
+++ b/modules/products/clion/build.gradle.kts
@@ -20,7 +20,11 @@ dependencies {
         ) { useInstaller = false }
 
         bundledPlugins("com.intellij.clion", "com.intellij.nativeDebug")
-        compatiblePlugin("com.jetbrains.cidr.base")
+        bundledModules(
+            "intellij.cidr.execution",
+            "intellij.cidr.projectModel",
+            "intellij.clion.toolchains",
+        )
 
         jetbrainsRuntime()
 


### PR DESCRIPTION
### Motivation
- Ensure the build includes the specific CLion modules required for execution, project model and toolchains rather than relying on a single compatible plugin reference.
- Avoid relying on `compatiblePlugin("com.jetbrains.cidr.base")`, which can be insufficient for packaging the needed CLion internals.

### Description
- Replaced `compatiblePlugin("com.jetbrains.cidr.base")` with explicit `bundledModules("intellij.cidr.execution", "intellij.cidr.projectModel", "intellij.clion.toolchains")` in `modules/products/clion/build.gradle.kts`.
- Left the surrounding `intellijPlatform` configuration, bundled plugins and test framework settings unchanged.

### Testing
- Ran the Gradle build for the CLion module with `./gradlew :modules:products:clion:build` and the task completed successfully.
- Ran module tests with `./gradlew :modules:products:clion:test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22e2d374c48330beb0d5e18161a88b)