### PR TITLE
Add task detection on include configs

### DIFF
--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/lang/psi/MiseTomlPsiPatterns.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/lang/psi/MiseTomlPsiPatterns.kt
@@ -1,5 +1,6 @@
 package com.github.l34130.mise.core.lang.psi
 
+import com.github.l34130.mise.core.model.MiseTomlFile
 import com.intellij.patterns.ElementPattern
 import com.intellij.patterns.ObjectPattern
 import com.intellij.patterns.PatternCondition
@@ -49,6 +50,23 @@ object MiseTomlPsiPatterns {
                 headerKeySegments?.singleOrNull()?.name == "tasks"
             }
 
+    private val RESERVED_TOP_LEVEL_TABLE_NAMES = setOf("tasks", "task_config", "env", "vars", "tools", "settings")
+
+    // Bare task table in a `[task_config].includes` file, e.g.
+    // [task4]
+    // run = "echo task4"
+    // See https://mise.jdx.dev/tasks/task-configuration.html
+    private val onBareTaskTable =
+        tomlPsiElement<TomlTable>()
+            .with("bareTaskTableShape") { table, _ ->
+                val segments = table.header.key?.segments
+                segments?.size == 1 && segments.first().name !in RESERVED_TOP_LEVEL_TABLE_NAMES
+            }
+            .with("isTaskIncludeFile") { table, _ ->
+                val virtualFile = table.containingFile?.originalFile?.virtualFile ?: return@with false
+                MiseTomlFile.isTaskIncludeFile(table.project, virtualFile)
+            }
+
     /**
      * ```toml
      * [tasks.foo]
@@ -58,6 +76,11 @@ object MiseTomlPsiPatterns {
      * [tasks]
      * foo = { $name = [] }
      *         #^
+     *
+     * # task_config.includes file
+     * [foo]
+     * $name = []
+     * #^
      * ```
      */
     fun onTaskProperty(name: String) =
@@ -66,7 +89,10 @@ object MiseTomlPsiPatterns {
             .withParent(onTaskSpecificTable) or
             psiElement<TomlKeyValue>()
                 .with("name") { e, _ -> e.key.name == name }
-                .withParent(psiElement<TomlInlineTable>().withSuperParent(2, onTaskTable))
+                .withParent(psiElement<TomlInlineTable>().withSuperParent(2, onTaskTable)) or
+            psiElement<TomlKeyValue>()
+                .with("name") { e, _ -> e.key.name == name }
+                .withParent(onBareTaskTable)
 
     /**
      * ```

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/model/MiseTomlFile.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/model/MiseTomlFile.kt
@@ -107,11 +107,20 @@ class MiseTomlFile {
             )
 
         /**
+         * Default file-task directories mise scans when no config file defines `task_config.includes`.
+         * Specifying `includes` explicitly overrides these defaults entirely (mise does not union them),
+         * so we only fall back to scanning these when no config file has an explicit `includes` list.
+         */
+        private val DEFAULT_TASK_DIRS =
+            listOf("mise-tasks", ".mise-tasks", ".mise/tasks", ".config/mise/tasks", "mise/tasks")
+
+        /**
          * Whether [file] is a TOML task file explicitly listed in `[task_config].includes`.
          *
          * Mise documents `task_config.includes` as explicit paths (Tera-templated) for TOML task files
-         * and file-task directories. We only treat direct TOML file includes as "task include files"
-         * for the purpose of accepting bare task tables like:
+         * and file-task directories. Both a directly-included `.toml` file and any `.toml` file nested
+         * inside an included (or default) directory are treated as "task include files" for the purpose
+         * of accepting bare task tables like:
          *
          * ```toml
          * [lint]
@@ -119,7 +128,6 @@ class MiseTomlFile {
          * ```
          *
          * We intentionally ignore:
-         * - directory includes (file tasks live there, not TOML)
          * - `git::` includes
          * - any Tera template we can't trivially resolve
          */
@@ -152,23 +160,48 @@ class MiseTomlFile {
                     .mapNotNull { path -> baseDir.findFileOrDirectory(path)?.takeIf { it.isFile } }
 
             val included = LinkedHashSet<String>()
+            var hasExplicitIncludes = false
             for (configVf in configFiles) {
                 val psiFile = configVf.findPsiFile(project) as? TomlFile ?: continue
                 val includes = TaskConfig.resolveOrNull(psiFile)?.includes ?: continue
-                for (rawInclude in includes) {
-                    val include = normalizeIncludePath(rawInclude) ?: continue
-                    if (!include.endsWith(".toml")) continue
+                hasExplicitIncludes = true
+                includes.forEach { addTomlFilesUnder(baseDir, normalizeIncludePath(it), included) }
+            }
 
-                    val target = baseDir.findFileOrDirectory(include)
-                    if (target?.isFile == true) {
-                        VfsUtilCore.getRelativePath(target, baseDir, '/')
-                            ?.replace('\\', '/')
-                            ?.let { included.add(it) }
-                    }
-                }
+            // No config file overrides the default file-task directories, so mise falls back to
+            // scanning them itself.
+            if (!hasExplicitIncludes) {
+                DEFAULT_TASK_DIRS.forEach { addTomlFilesUnder(baseDir, it, included) }
             }
 
             return included
+        }
+
+        /**
+         * Resolves [path] (relative to [baseDir]) and adds every `.toml` file found there to [included] —
+         * the file itself if [path] points at one, or every `.toml` file nested inside it if it's a directory.
+         */
+        private fun addTomlFilesUnder(
+            baseDir: VirtualFile,
+            path: String?,
+            included: MutableSet<String>,
+        ) {
+            val target = path?.let { baseDir.findFileOrDirectory(it) } ?: return
+            if (target.isFile) {
+                if (target.extension == "toml") included.addRelativePath(target, baseDir)
+            } else {
+                VfsUtilCore.iterateChildrenRecursively(target, null) { child ->
+                    if (child.isFile && child.extension == "toml") included.addRelativePath(child, baseDir)
+                    true
+                }
+            }
+        }
+
+        private fun MutableSet<String>.addRelativePath(
+            file: VirtualFile,
+            baseDir: VirtualFile,
+        ) {
+            VfsUtilCore.getRelativePath(file, baseDir, '/')?.replace('\\', '/')?.let { add(it) }
         }
 
         private fun normalizeIncludePath(rawInclude: String): String? {

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/model/MiseTomlFile.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/model/MiseTomlFile.kt
@@ -4,8 +4,15 @@ import com.github.l34130.mise.core.lang.psi.getValueWithKey
 import com.github.l34130.mise.core.lang.psi.stringValue
 import com.github.l34130.mise.core.util.guessMiseProjectDir
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VfsUtilCore
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.findFileOrDirectory
+import com.intellij.openapi.vfs.findPsiFile
+import com.intellij.openapi.vfs.isFile
+import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.psi.util.childrenOfType
+import com.intellij.psi.util.CachedValueProvider
+import com.intellij.psi.util.CachedValuesManager
 import com.intellij.testFramework.LightVirtualFile
 import org.toml.lang.psi.TomlArray
 import org.toml.lang.psi.TomlFile
@@ -87,5 +94,97 @@ class MiseTomlFile {
             } else {
                 this == project.guessMiseProjectDir()
             }
+
+        /**
+         * Candidate locations for the main mise config file, checked without shelling out to `mise`.
+         * Kept in sync with the well-known paths mise itself resolves by default.
+         */
+        private val DEFAULT_CONFIG_FILE_PATHS =
+            listOf(
+                "mise.toml", ".mise.toml", "mise.local.toml", ".mise.local.toml",
+                "mise/config.toml", ".mise/config.toml",
+                ".config/mise.toml", ".config/mise/config.toml",
+            )
+
+        /**
+         * Whether [file] is a TOML task file explicitly listed in `[task_config].includes`.
+         *
+         * Mise documents `task_config.includes` as explicit paths (Tera-templated) for TOML task files
+         * and file-task directories. We only treat direct TOML file includes as "task include files"
+         * for the purpose of accepting bare task tables like:
+         *
+         * ```toml
+         * [lint]
+         * run = "echo hi"
+         * ```
+         *
+         * We intentionally ignore:
+         * - directory includes (file tasks live there, not TOML)
+         * - `git::` includes
+         * - any Tera template we can't trivially resolve
+         */
+        fun isTaskIncludeFile(
+            project: Project,
+            file: VirtualFile,
+        ): Boolean {
+            if (!file.isValid || file.fileType != TomlFileType) return false
+            val baseDir = project.guessMiseProjectDir()
+            val rel = VfsUtilCore.getRelativePath(file, baseDir, '/')?.replace('\\', '/') ?: return false
+            return getIncludedTomlRelativePaths(project).contains(rel)
+        }
+
+        private fun getIncludedTomlRelativePaths(project: Project): Set<String> {
+            val manager = CachedValuesManager.getManager(project)
+            return manager.getCachedValue(project) {
+                CachedValueProvider.Result.create(
+                    computeIncludedTomlRelativePaths(project),
+                    // Keep this cheap and safe: invalidate on any VFS structure/content change.
+                    VirtualFileManager.VFS_STRUCTURE_MODIFICATIONS,
+                )
+            }
+        }
+
+        private fun computeIncludedTomlRelativePaths(project: Project): Set<String> {
+            val baseDir = project.guessMiseProjectDir()
+
+            val configFiles =
+                DEFAULT_CONFIG_FILE_PATHS
+                    .mapNotNull { path -> baseDir.findFileOrDirectory(path)?.takeIf { it.isFile } }
+
+            val included = LinkedHashSet<String>()
+            for (configVf in configFiles) {
+                val psiFile = configVf.findPsiFile(project) as? TomlFile ?: continue
+                val includes = TaskConfig.resolveOrNull(psiFile)?.includes ?: continue
+                for (rawInclude in includes) {
+                    val include = normalizeIncludePath(rawInclude) ?: continue
+                    if (!include.endsWith(".toml")) continue
+
+                    val target = baseDir.findFileOrDirectory(include)
+                    if (target?.isFile == true) {
+                        VfsUtilCore.getRelativePath(target, baseDir, '/')
+                            ?.replace('\\', '/')
+                            ?.let { included.add(it) }
+                    }
+                }
+            }
+
+            return included
+        }
+
+        private fun normalizeIncludePath(rawInclude: String): String? {
+            var s = rawInclude.trim().replace('\\', '/')
+            if (s.startsWith("git::")) return null
+
+            // Includes are Tera templates. We only support the common config_root variable.
+            s = s.replace("\\{\\{\\s*config_root\\s*}}".toRegex(), "")
+            if (s.contains("{{")) return null
+
+            while (s.startsWith("./")) s = s.removePrefix("./")
+            // mise includes are typically relative; treat absolute-leading slashes as relative to base.
+            while (s.startsWith('/')) s = s.removePrefix("/")
+            // A directory include may be written as `tasks/`; VirtualFile resolution expects no trailing slash.
+            while (s.endsWith('/')) s = s.removeSuffix("/")
+            return s.ifBlank { null }
+        }
     }
 }

--- a/modules/core/src/test/kotlin/com/github/l34130/mise/core/lang/psi/MiseTomlPsiPatternsTest.kt
+++ b/modules/core/src/test/kotlin/com/github/l34130/mise/core/lang/psi/MiseTomlPsiPatternsTest.kt
@@ -47,6 +47,72 @@ class MiseTomlPsiPatternsTest : FileTestBase() {
                  #^
     """)
 
+    fun `test inTaskRunStringOrArray on bare task table in include file`() {
+        myFixture.addFileToProject("mise.toml", """
+            [task_config]
+            includes = ["buf.toml"]
+        """.trimIndent())
+
+        val bufToml = myFixture.addFileToProject("buf.toml", """
+            ["buf:lint"]
+            run = '''
+            echo hi
+            #^
+            '''
+        """.trimIndent())
+
+        myFixture.configureFromExistingVirtualFile(bufToml.virtualFile)
+
+        val element = findElementInEditor<PsiElement>()
+        assert(MiseTomlPsiPatterns.inTaskRunStringOrArray.accepts(element)) {
+            "Pattern does not accept element at caret:\n${myFixture.file.text}"
+        }
+    }
+
+    fun `test inTaskRunStringOrArray on bare task table in include file with trailing slash dir include`() {
+        myFixture.addFileToProject("mise.toml", """
+            [task_config]
+            includes = ["tasks/"]
+        """.trimIndent())
+
+        val bufToml = myFixture.addFileToProject("tasks/buf.toml", """
+            [lint]
+            run = '''
+            echo hi
+            #^
+            '''
+        """.trimIndent())
+
+        myFixture.configureFromExistingVirtualFile(bufToml.virtualFile)
+
+        val element = findElementInEditor<PsiElement>()
+        assert(!MiseTomlPsiPatterns.inTaskRunStringOrArray.accepts(element)) {
+            "Pattern unexpectedly accepts element at caret (directory include should not mark TOML as included):\n${myFixture.file.text}"
+        }
+    }
+
+    fun `test inTaskRunStringOrArray on bare task table in tasks dir without includes`() {
+        myFixture.addFileToProject("mise.toml", """
+            [tools]
+            node = "20"
+        """.trimIndent())
+
+        val bufToml = myFixture.addFileToProject("tasks/buf.toml", """
+            [lint]
+            run = '''
+            echo hi
+            #^
+            '''
+        """.trimIndent())
+
+        myFixture.configureFromExistingVirtualFile(bufToml.virtualFile)
+
+        val element = findElementInEditor<PsiElement>()
+        assert(!MiseTomlPsiPatterns.inTaskRunStringOrArray.accepts(element)) {
+            "Pattern unexpectedly accepts element at caret (no [task_config].includes):\n${myFixture.file.text}"
+        }
+    }
+
     private inline fun <reified T : PsiElement> testPattern(
         pattern: ElementPattern<T>,
         @Language("TOML") code: String,


### PR DESCRIPTION
Problem: https://mise.jdx.dev/tasks/task-configuration.html#task-config-includes won't be detected brecause they aren't prefixed with task,

AI-generated, but I wanted a quick demonstration to handle tasks from configs via default settings or if defined with an include
