### PR TITLE
Fix Windows mise task -C path

### DIFF
--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/execution/configuration/MiseTomlTaskRunConfiguration.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/execution/configuration/MiseTomlTaskRunConfiguration.kt
@@ -20,7 +20,6 @@ import com.intellij.openapi.vfs.encoding.EncodingManager
 import com.intellij.util.EnvironmentUtil
 import com.intellij.util.execution.ParametersListUtil
 import org.jdom.Element
-import java.io.File
 
 class MiseTomlTaskRunConfiguration(
     project: Project,
@@ -45,8 +44,7 @@ class MiseTomlTaskRunConfiguration(
 
                 val macroManager = PathMacroManager.getInstance(project)
                 val expandedWorkingDirectory = macroManager.expandPath(workingDirectory)
-                val workDirectory =
-                    FileUtil.getRelativePath(projectBasePath, expandedWorkingDirectory, File.separatorChar) ?: expandedWorkingDirectory
+                val workDirectory = resolveMiseCdArgument(projectBasePath, expandedWorkingDirectory)
 
                 val params = mutableListOf<String>()
                 params += "-C"
@@ -105,4 +103,13 @@ class MiseTomlTaskRunConfiguration(
         taskParams = child.getAttributeValue("taskParams") ?: ""
         envVars = EnvironmentVariablesData.readExternal(child)
     }
+}
+
+internal fun resolveMiseCdArgument(
+    projectBasePath: String,
+    expandedWorkingDirectory: String,
+): String {
+    val normalizedProjectBasePath = FileUtil.toSystemIndependentName(projectBasePath)
+    val normalizedWorkingDirectory = FileUtil.toSystemIndependentName(expandedWorkingDirectory)
+    return FileUtil.getRelativePath(normalizedProjectBasePath, normalizedWorkingDirectory, '/') ?: normalizedWorkingDirectory
 }

--- a/modules/core/src/test/kotlin/com/github/l34130/mise/core/execution/configuration/MiseTomlTaskRunConfigurationPathTest.kt
+++ b/modules/core/src/test/kotlin/com/github/l34130/mise/core/execution/configuration/MiseTomlTaskRunConfigurationPathTest.kt
@@ -1,0 +1,53 @@
+package com.github.l34130.mise.core.execution.configuration
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class MiseTomlTaskRunConfigurationPathTest {
+    @Test
+    fun `test Windows task directory is converted to system independent relative path`() {
+        val cdArgument =
+            resolveMiseCdArgument(
+                projectBasePath = "C:\\Users\\dev\\project",
+                expandedWorkingDirectory = "C:\\Users\\dev\\project\\.mise-tasks\\build",
+            )
+
+        assertEquals(".mise-tasks/build", cdArgument)
+    }
+
+    @Test
+    fun `test Windows parent relative task directory does not contain malformed drive separator`() {
+        val cdArgument =
+            resolveMiseCdArgument(
+                projectBasePath = "C:\\Users\\dev\\project\\module",
+                expandedWorkingDirectory = "C:\\Users\\dev\\project\\.mise-tasks\\build",
+            )
+
+        assertEquals("../.mise-tasks/build", cdArgument)
+        assertFalse(cdArgument.contains(":\\"))
+        assertFalse(cdArgument.contains(":/"))
+    }
+
+    @Test
+    fun `test Windows different drive task directory falls back to absolute path`() {
+        val cdArgument =
+            resolveMiseCdArgument(
+                projectBasePath = "C:\\Users\\dev\\project",
+                expandedWorkingDirectory = "D:\\tasks\\build",
+            )
+
+        assertEquals("D:/tasks/build", cdArgument)
+    }
+
+    @Test
+    fun `test Unix task directory keeps existing relative path behavior`() {
+        val cdArgument =
+            resolveMiseCdArgument(
+                projectBasePath = "/home/dev/project",
+                expandedWorkingDirectory = "/home/dev/project/.mise-tasks/build",
+            )
+
+        assertEquals(".mise-tasks/build", cdArgument)
+    }
+}


### PR DESCRIPTION
## Summary
- Normalize project and task working directories before computing the mise `-C` argument.
- Compute relative paths with `/` separators to avoid malformed Windows paths like `..\:/...`.
- Add direct path tests for Windows same-drive, parent-relative, different-drive, and Unix cases.

## Tests
- `./gradlew :mise-core:test --tests com.github.l34130.mise.core.execution.configuration.MiseTomlTaskRunConfigurationPathTest`

Fixes #515