### PR TITLE
Fix mise task run directory handling

### DIFF
--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/execution/configuration/MiseTomlTaskRunConfiguration.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/execution/configuration/MiseTomlTaskRunConfiguration.kt
@@ -20,6 +20,7 @@ import com.intellij.openapi.vfs.encoding.EncodingManager
 import com.intellij.util.EnvironmentUtil
 import com.intellij.util.execution.ParametersListUtil
 import org.jdom.Element
+import java.io.File
 
 class MiseTomlTaskRunConfiguration(
     project: Project,
@@ -40,46 +41,49 @@ class MiseTomlTaskRunConfiguration(
     ): RunProfileState {
         return object : CommandLineState(executionEnvironment) {
             override fun startProcess(): ProcessHandler {
-                val projectBasePath = project.guessMiseProjectPath()
-
-                val macroManager = PathMacroManager.getInstance(project)
-                val expandedWorkingDirectory = macroManager.expandPath(workingDirectory)
-                val workDirectory = resolveMiseCdArgument(projectBasePath, expandedWorkingDirectory)
-
-                val params = mutableListOf<String>()
-                params += "-C"
-                params += workDirectory
-                if (miseConfigEnvironment.isNotBlank()) {
-                    params += listOf("--env", miseConfigEnvironment)
-                }
-                params += listOf("run", miseTaskName)
-                if (taskParams.isNotBlank()) {
-                    params += "--"
-                    params += ParametersListUtil.parse(taskParams)
-                }
-
-                val commandLine = PtyCommandLine()
-                if (!SystemInfo.isWindows) {
-                    commandLine.withEnvironment("TERM", "xterm-256color")
-                }
-                commandLine.withConsoleMode(false)
-                commandLine.withInitialColumns(120)
-                commandLine.withCharset(EncodingManager.getInstance().defaultConsoleEncoding)
-                commandLine.withEnvironment(EnvironmentUtil.getEnvironmentMap() + envVars.envs)
-                commandLine.withParentEnvironmentType(GeneralCommandLine.ParentEnvironmentType.CONSOLE)
-                commandLine.withWorkDirectory(projectBasePath)
-                commandLine.withParameters(params)
-
-                val executableManager = project.service<MiseExecutableManager>()
-                val miseExecutablePath = executableManager.getExecutablePath()
-                commandLine.withExePath(miseExecutablePath)
-
-                return ColoredProcessHandler(commandLine).apply {
+                return ColoredProcessHandler(createCommandLine()).apply {
                     setShouldKillProcessSoftly(true)
                     ProcessTerminatedListener.attach(this)
                 }
             }
         }
+    }
+
+    internal fun createCommandLine(): PtyCommandLine {
+        val projectBasePath = project.guessMiseProjectPath()
+
+        val macroManager = PathMacroManager.getInstance(project)
+        val expandedWorkingDirectory = macroManager.expandPath(workingDirectory)
+        val miseCd = resolveMiseCd(projectBasePath, expandedWorkingDirectory)
+
+        val params = mutableListOf<String>()
+        if (miseConfigEnvironment.isNotBlank()) {
+            params += listOf("--env", miseConfigEnvironment)
+        }
+        params += listOf("run", miseTaskName)
+        if (taskParams.isNotBlank()) {
+            params += "--"
+            params += ParametersListUtil.parse(taskParams)
+        }
+
+        val commandLine = PtyCommandLine()
+        if (!SystemInfo.isWindows) {
+            commandLine.withEnvironment("TERM", "xterm-256color")
+        }
+        commandLine.withConsoleMode(false)
+        commandLine.withInitialColumns(120)
+        commandLine.withCharset(EncodingManager.getInstance().defaultConsoleEncoding)
+        commandLine.withEnvironment(EnvironmentUtil.getEnvironmentMap() + envVars.envs)
+        commandLine.withEnvironment(MISE_CD_ENV, miseCd)
+        commandLine.withParentEnvironmentType(GeneralCommandLine.ParentEnvironmentType.CONSOLE)
+        commandLine.withWorkDirectory(projectBasePath)
+        commandLine.withParameters(params)
+
+        val executableManager = project.service<MiseExecutableManager>()
+        val miseExecutablePath = executableManager.getExecutablePath()
+        commandLine.withExePath(miseExecutablePath)
+
+        return commandLine
     }
 
     override fun getConfigurationEditor(): SettingsEditor<out RunConfiguration> = MiseTomlTaskRunConfigurationEditor(project)
@@ -103,13 +107,25 @@ class MiseTomlTaskRunConfiguration(
         taskParams = child.getAttributeValue("taskParams") ?: ""
         envVars = EnvironmentVariablesData.readExternal(child)
     }
+
+    private companion object {
+        const val MISE_CD_ENV = "MISE_CD"
+    }
 }
 
-internal fun resolveMiseCdArgument(
+internal fun resolveMiseCd(
     projectBasePath: String,
     expandedWorkingDirectory: String,
 ): String {
     val normalizedProjectBasePath = FileUtil.toSystemIndependentName(projectBasePath)
-    val normalizedWorkingDirectory = FileUtil.toSystemIndependentName(expandedWorkingDirectory)
-    return FileUtil.getRelativePath(normalizedProjectBasePath, normalizedWorkingDirectory, '/') ?: normalizedWorkingDirectory
+    val normalizedWorkingDirectory =
+        FileUtil.toSystemIndependentName(expandedWorkingDirectory).ifBlank { normalizedProjectBasePath }
+    return if (normalizedWorkingDirectory.isAbsolutePath()) {
+        normalizedWorkingDirectory
+    } else {
+        FileUtil.toSystemIndependentName(File(normalizedProjectBasePath, normalizedWorkingDirectory).path)
+    }
 }
+
+private fun String.isAbsolutePath(): Boolean =
+    startsWith("/") || startsWith("//") || matches(Regex("^[A-Za-z]:/.*"))

--- a/modules/core/src/test/kotlin/com/github/l34130/mise/core/execution/MiseTomlTaskRunConfigurationProducerTest.kt
+++ b/modules/core/src/test/kotlin/com/github/l34130/mise/core/execution/MiseTomlTaskRunConfigurationProducerTest.kt
@@ -2,9 +2,17 @@
 package com.github.l34130.mise.core.execution
 
 import com.github.l34130.mise.core.FileTestBase
+import com.github.l34130.mise.core.cache.MiseCacheService
+import com.github.l34130.mise.core.command.MiseExecutableInfo
+import com.github.l34130.mise.core.command.MiseExecutableManager
+import com.github.l34130.mise.core.execution.configuration.MiseTomlTaskRunConfiguration
+import com.github.l34130.mise.core.execution.configuration.MiseTomlTaskRunConfigurationFactory
 import com.github.l34130.mise.core.execution.configuration.MiseTomlTaskRunConfigurationProducer
+import com.github.l34130.mise.core.execution.configuration.MiseTomlTaskRunConfigurationType
 import com.intellij.execution.PsiLocation
 import com.intellij.execution.actions.ConfigurationContext
+import com.intellij.execution.configuration.EnvironmentVariablesData
+import com.intellij.openapi.components.service
 import com.intellij.psi.PsiElement
 import org.intellij.lang.annotations.Language
 import org.toml.lang.psi.TomlFile
@@ -48,7 +56,55 @@ class MiseTomlTaskRunConfigurationProducerTest : FileTestBase() {
         assertEquals("Run bar", configurationFromContext?.configurationSettings?.name)
     }
 
+    fun `test task command line uses MISE_CD instead of cd flag`() {
+        seedExecutableInfo()
+        val configuration = createRunConfiguration().apply {
+            miseConfigEnvironment = "development"
+            miseTaskName = "show"
+            workingDirectory = "${'$'}PROJECT_DIR${'$'}/subdir"
+            taskParams = "--flag value"
+            envVars = EnvironmentVariablesData.create(mapOf("MISE_CD" to "/user/value"), true)
+        }
+
+        val commandLine = configuration.createCommandLine()
+
+        assertEquals(project.basePath, commandLine.workDirectory?.path)
+        assertEquals(project.basePath + "/subdir", commandLine.environment["MISE_CD"])
+        assertFalse(commandLine.parametersList.parameters.contains("-C"))
+        assertEquals(
+            listOf("--env", "development", "run", "show", "--", "--flag", "value"),
+            commandLine.parametersList.parameters,
+        )
+    }
+
+    fun `test task command line converts relative MISE_CD to absolute path`() {
+        seedExecutableInfo()
+        val configuration = createRunConfiguration().apply {
+            miseTaskName = "show"
+            workingDirectory = "subdir"
+        }
+
+        val commandLine = configuration.createCommandLine()
+
+        assertEquals(project.basePath + "/subdir", commandLine.environment["MISE_CD"])
+        assertEquals(listOf("run", "show"), commandLine.parametersList.parameters)
+    }
+
     private fun createConfigurationContext(element: PsiElement): ConfigurationContext {
         return ConfigurationContext.createEmptyContextForLocation(PsiLocation.fromPsiElement(myFixture.project, element))
+    }
+
+    private fun seedExecutableInfo(path: String = "mise") {
+        val cacheService = project.service<MiseCacheService>()
+        cacheService.invalidateAllExecutables()
+        cacheService.getOrComputeExecutable(MiseExecutableManager.EXECUTABLE_KEY) {
+            MiseExecutableInfo(path = path, version = null)
+        }
+    }
+
+    private fun createRunConfiguration(): MiseTomlTaskRunConfiguration {
+        val configurationType = MiseTomlTaskRunConfigurationType()
+        val factory = MiseTomlTaskRunConfigurationFactory(configurationType)
+        return MiseTomlTaskRunConfiguration(project, factory, "Run show")
     }
 }

--- a/modules/core/src/test/kotlin/com/github/l34130/mise/core/execution/configuration/MiseTomlTaskRunConfigurationPathTest.kt
+++ b/modules/core/src/test/kotlin/com/github/l34130/mise/core/execution/configuration/MiseTomlTaskRunConfigurationPathTest.kt
@@ -6,48 +6,47 @@ import org.junit.Test
 
 class MiseTomlTaskRunConfigurationPathTest {
     @Test
-    fun `test Windows task directory is converted to system independent relative path`() {
-        val cdArgument =
-            resolveMiseCdArgument(
+    fun `test Windows task directory is converted to system independent absolute path`() {
+        val miseCd =
+            resolveMiseCd(
                 projectBasePath = "C:\\Users\\dev\\project",
                 expandedWorkingDirectory = "C:\\Users\\dev\\project\\.mise-tasks\\build",
             )
 
-        assertEquals(".mise-tasks/build", cdArgument)
+        assertEquals("C:/Users/dev/project/.mise-tasks/build", miseCd)
     }
 
     @Test
-    fun `test Windows parent relative task directory does not contain malformed drive separator`() {
-        val cdArgument =
-            resolveMiseCdArgument(
+    fun `test Windows parent task directory remains absolute`() {
+        val miseCd =
+            resolveMiseCd(
                 projectBasePath = "C:\\Users\\dev\\project\\module",
                 expandedWorkingDirectory = "C:\\Users\\dev\\project\\.mise-tasks\\build",
             )
 
-        assertEquals("../.mise-tasks/build", cdArgument)
-        assertFalse(cdArgument.contains(":\\"))
-        assertFalse(cdArgument.contains(":/"))
+        assertEquals("C:/Users/dev/project/.mise-tasks/build", miseCd)
+        assertFalse(miseCd.contains("\\"))
     }
 
     @Test
     fun `test Windows different drive task directory falls back to absolute path`() {
-        val cdArgument =
-            resolveMiseCdArgument(
+        val miseCd =
+            resolveMiseCd(
                 projectBasePath = "C:\\Users\\dev\\project",
                 expandedWorkingDirectory = "D:\\tasks\\build",
             )
 
-        assertEquals("D:/tasks/build", cdArgument)
+        assertEquals("D:/tasks/build", miseCd)
     }
 
     @Test
-    fun `test Unix task directory keeps existing relative path behavior`() {
-        val cdArgument =
-            resolveMiseCdArgument(
+    fun `test Unix task directory remains absolute`() {
+        val miseCd =
+            resolveMiseCd(
                 projectBasePath = "/home/dev/project",
                 expandedWorkingDirectory = "/home/dev/project/.mise-tasks/build",
             )
 
-        assertEquals(".mise-tasks/build", cdArgument)
+        assertEquals("/home/dev/project/.mise-tasks/build", miseCd)
     }
 }


### PR DESCRIPTION
## Summary
- replace mise task run configuration's `-C <dir>` invocation with `MISE_CD`
- keep task execution rooted at the project base while passing an absolute task directory to mise
- add regression coverage for the generated command line and relative working directories

Closes #511

## Tests
- `./gradlew :mise-core:compileTestKotlin`