### PR TITLE
Skip mise configs in excluded folders

### DIFF
--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/MiseConfigFileResolver.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/MiseConfigFileResolver.kt
@@ -115,6 +115,7 @@ class MiseConfigFileResolver(
             .filter { it.endsWith(".toml", ignoreCase = true) }
             .mapNotNull { fs.refreshAndFindFileByPath(it) }
             .filter { it.isFile }
+            .filterNot { project.isExcludedFromMiseResolution(it) }
             .distinctBy { normalizePath(it.path) }
             .toList()
     }
@@ -154,7 +155,7 @@ class MiseConfigFileResolver(
                 addIfNotNull(baseDirVf.findFileOrDirectory("mise.toml")?.takeIf { it.isFile })
                 addIfNotNull(baseDirVf.findFileOrDirectory(".mise.local.toml")?.takeIf { it.isFile })
                 addIfNotNull(baseDirVf.findFileOrDirectory(".mise.toml")?.takeIf { it.isFile })
-            }
+            }.filterNot { project.isExcludedFromMiseResolution(it) }
         }
     }
 
@@ -185,6 +186,7 @@ class MiseConfigFileResolver(
         return mergedFiles
             .asSequence()
             .filter { it.isFile }
+            .filterNot { project.isExcludedFromMiseResolution(it) }
             .distinctBy { normalizePath(it.path) }
             .toList()
     }

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/MiseProjectFileIndex.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/MiseProjectFileIndex.kt
@@ -1,0 +1,10 @@
+package com.github.l34130.mise.core
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ProjectFileIndex
+import com.intellij.openapi.vfs.VirtualFile
+
+internal fun Project.isExcludedFromMiseResolution(file: VirtualFile): Boolean {
+    if (isDisposed || !file.isValid) return false
+    return ProjectFileIndex.getInstance(this).isExcluded(file)
+}

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/MiseTomlFileListener.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/MiseTomlFileListener.kt
@@ -99,6 +99,7 @@ class MiseTomlFileListener(
             }
 
             private fun isTrackedMiseInput(file: VirtualFile): Boolean {
+                if (project.isExcludedFromMiseResolution(file)) return false
                 if (project.service<MiseConfigFileResolver>().isTrackedPath(file)) return true
                 if (MiseTomlFile.isMiseTomlFile(project, file)) return true
                 return isLikelyMiseRelatedFile(file)

--- a/modules/core/src/test/kotlin/com/github/l34130/mise/core/MiseConfigFileResolverTest.kt
+++ b/modules/core/src/test/kotlin/com/github/l34130/mise/core/MiseConfigFileResolverTest.kt
@@ -9,7 +9,9 @@ import com.github.l34130.mise.core.command.MiseVersion
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.process.ProcessOutput
 import com.intellij.openapi.components.service
+import com.intellij.openapi.roots.ModuleRootModificationUtil
 import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import kotlinx.coroutines.runBlocking
@@ -47,6 +49,18 @@ class MiseConfigFileResolverTest : BasePlatformTestCase() {
         cacheService.getOrComputeExecutable(MiseExecutableManager.EXECUTABLE_KEY) {
             MiseExecutableInfo(path = path, version = version)
         }
+    }
+
+    private fun excludeFolder(
+        contentRoot: VirtualFile,
+        excludedFolder: VirtualFile,
+    ) {
+        ModuleRootModificationUtil.updateExcludedFolders(
+            module,
+            contentRoot,
+            listOf(excludedFolder.url),
+            emptyList(),
+        )
     }
 
     fun `test resolveTrackedFiles falls back to manual scan and tracks external env files`() {
@@ -139,5 +153,83 @@ class MiseConfigFileResolverTest : BasePlatformTestCase() {
         val configPaths = configs.map { it.path }.toSet()
         assertTrue(configPaths.contains(parentToml.toString().replace('\\', '/')))
         assertTrue(configPaths.contains(childToml.toString().replace('\\', '/')))
+    }
+
+    fun `test resolveConfigFiles ignores CLI configs in excluded folders`() {
+        seedExecutableInfo()
+        val rootDir = Files.createTempDirectory("mise-excluded-config-test")
+        val includedToml = rootDir.resolve("mise.toml").also { it.writeText("[tools]\nnode = '22'\n") }
+        val templatesDir = rootDir.resolve("templates").createDirectories()
+        val excludedToml = templatesDir.resolve("mise.toml").also { it.writeText("[tools]\nnode = '20'\n") }
+
+        val baseDirVf =
+            LocalFileSystem.getInstance().refreshAndFindFileByPath(rootDir.toString().replace('\\', '/'))
+                ?: error("Failed to resolve project dir in VFS")
+        val templatesDirVf =
+            LocalFileSystem.getInstance().refreshAndFindFileByPath(templatesDir.toString().replace('\\', '/'))
+                ?: error("Failed to resolve templates dir in VFS")
+        ModuleRootModificationUtil.addContentRoot(module, baseDirVf)
+        excludeFolder(baseDirVf, templatesDirVf)
+
+        val resolver = project.service<MiseConfigFileResolver>()
+        val configs =
+            withCommandLineExecutor(
+                executor = { commandLine, _ ->
+                    val cmdStr = commandLine.commandLineString
+                    when {
+                        cmdStr.contains("config ls --json") -> {
+                            val json = """
+                                [
+                                  {"path": "${includedToml.toString().replace('\\', '/')}"},
+                                  {"path": "${excludedToml.toString().replace('\\', '/')}"}
+                                ]
+                            """.trimIndent()
+                            processOutput(stdout = json)
+                        }
+                        cmdStr.contains("config --tracked-configs") -> {
+                            processOutput(
+                                stdout = "${includedToml.toString().replace('\\', '/')}\n${excludedToml.toString().replace('\\', '/')}\n",
+                            )
+                        }
+                        else -> processOutput()
+                    }
+                },
+            ) {
+                runBlocking {
+                    resolver.resolveConfigFiles(baseDirVf, refresh = true, configEnvironment = "test")
+                }
+            }
+
+        assertEquals(listOf(includedToml.toString().replace('\\', '/')), configs.map { it.path })
+    }
+
+    fun `test resolveTrackedFiles fallback ignores excluded config and external files`() {
+        seedExecutableInfo()
+        myFixture.configureByText(
+            "mise.toml",
+            """
+            env_file = "secrets/.env"
+            """.trimIndent(),
+        )
+        val externalEnvFile = myFixture.configureByText("secrets/.env", "FOO=BAR").virtualFile
+        val excludedConfigFile = myFixture.configureByText(".config/mise.toml", "[tools]\nnode = '20'\n").virtualFile
+        val baseDirVf = VirtualFileManager.getInstance().findFileByUrl("temp:///src") ?: error("Base directory not found")
+        excludeFolder(baseDirVf, excludedConfigFile.parent)
+        excludeFolder(baseDirVf, externalEnvFile.parent)
+
+        val resolver = project.service<MiseConfigFileResolver>()
+        val snapshot =
+            withCommandLineExecutor(
+                executor = { _, _ -> processOutput(stderr = "command failed", exitCode = 1) },
+            ) {
+                runBlocking {
+                    resolver.resolveTrackedFiles(baseDirVf, refresh = true, configEnvironment = "test")
+                }
+            }
+
+        assertEquals(listOf("/src/mise.toml"), snapshot.configTomlFiles.map { it.path })
+        assertEquals(emptyList<String>(), snapshot.externalTrackedFiles.map { it.path })
+        assertFalse(snapshot.normalizedTrackedPaths.contains(excludedConfigFile.path))
+        assertFalse(snapshot.normalizedTrackedPaths.contains(externalEnvFile.path))
     }
 }


### PR DESCRIPTION
## Summary
- Skip mise config files and external tracked inputs when IntelliJ marks them as excluded.
- Ignore excluded mise-related VFS changes before invalidating mise caches.
- Add resolver coverage for CLI-discovered and fallback-discovered excluded files.

## Tests
- git -c core.fsmonitor=false diff --check
- ./gradlew :mise-core:compileKotlin
- ./gradlew :mise-core:compileTestKotlin
- Attempted: ./gradlew :mise-core:test --tests com.github.l34130.mise.core.MiseConfigFileResolverTest --no-parallel -Dkotlinx.coroutines.debug=off; interrupted after hanging during IntelliJ test app initialization.

Fixes #510