### PR TITLE
Fix SDK refresh after mise config changes

### DIFF
--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/MiseConfigFileResolver.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/MiseConfigFileResolver.kt
@@ -73,14 +73,15 @@ class MiseConfigFileResolver(
             snapshotByContext[cacheKey]?.let { return it }
         }
 
-        val trackedTomlFiles =
-            resolveTrackedTomlFiles(baseDirVf, configEnvironment).ifEmpty {
-                resolveFallbackTomlFiles(baseDirVf, configEnvironment)
+        val trackedConfigInputs =
+            resolveTrackedConfigInputs(configEnvironment).ifEmpty {
+                resolveFallbackTrackedConfigInputs(baseDirVf, configEnvironment)
             }
+        val trackedTomlFiles = trackedConfigInputs.filter { it.isTomlFile() }
 
         val configRoot = computeConfigRoot(trackedTomlFiles.firstOrNull(), baseDirVf)
         val externalTrackedFiles = resolveExternalTrackedFiles(trackedTomlFiles, configRoot, baseDirVf)
-        val allTrackedFiles = (trackedTomlFiles + externalTrackedFiles).distinctBy { normalizePath(it.path) }
+        val allTrackedFiles = (trackedConfigInputs + externalTrackedFiles).distinctBy { normalizePath(it.path) }
         val snapshot =
             TrackedConfigSnapshot(
                 configTomlFiles = trackedTomlFiles,
@@ -102,8 +103,7 @@ class MiseConfigFileResolver(
 
     override fun dispose() { }
 
-    private fun resolveTrackedTomlFiles(
-        baseDirVf: VirtualFile,
+    private fun resolveTrackedConfigInputs(
         configEnvironment: String?,
     ): List<VirtualFile> {
         val activeConfigs =
@@ -112,15 +112,14 @@ class MiseConfigFileResolver(
         val fs = LocalFileSystem.getInstance()
         return activeConfigs
             .asSequence()
-            .filter { it.endsWith(".toml", ignoreCase = true) }
-            .mapNotNull { fs.refreshAndFindFileByPath(it) }
+            .mapNotNull { fs.refreshAndFindFileByPath(normalizePath(it)) }
             .filter { it.isFile }
             .filterNot { project.isExcludedFromMiseResolution(it) }
             .distinctBy { normalizePath(it.path) }
             .toList()
     }
 
-    private suspend fun resolveFallbackTomlFiles(
+    private suspend fun resolveFallbackTrackedConfigInputs(
         baseDirVf: VirtualFile,
         configEnvironment: String?,
     ): List<VirtualFile> {
@@ -155,6 +154,8 @@ class MiseConfigFileResolver(
                 addIfNotNull(baseDirVf.findFileOrDirectory("mise.toml")?.takeIf { it.isFile })
                 addIfNotNull(baseDirVf.findFileOrDirectory(".mise.local.toml")?.takeIf { it.isFile })
                 addIfNotNull(baseDirVf.findFileOrDirectory(".mise.toml")?.takeIf { it.isFile })
+                addIfNotNull(baseDirVf.findFileOrDirectory(".tool-versions")?.takeIf { it.isFile })
+                addIfNotNull(baseDirVf.findFileOrDirectory(".tool-versions.local")?.takeIf { it.isFile })
             }.filterNot { project.isExcludedFromMiseResolution(it) }
         }
     }
@@ -277,6 +278,8 @@ class MiseConfigFileResolver(
             globalTrackedPathIndex.addAll(snapshot.normalizedTrackedPaths)
         }
     }
+
+    private fun VirtualFile.isTomlFile(): Boolean = name.endsWith(".toml", ignoreCase = true)
 
     private fun normalizePath(path: String): String {
         val normalized =

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/MiseTomlFileListener.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/MiseTomlFileListener.kt
@@ -19,6 +19,16 @@ import com.intellij.util.messages.MessageBusConnection
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
 
+internal fun isLikelyMiseRelatedFileName(name: String): Boolean {
+    if (name == "config.toml" || name == "mise.toml" || name == ".mise.toml") return true
+    if (name == "mise.local.toml" || name == ".mise.local.toml") return true
+    if (name == ".tool-versions" || name == ".tool-versions.local") return true
+    if (name.startsWith(".env")) return true
+    if (name.matches("^mise\\.[^/]+\\.toml$".toRegex())) return true
+    if (name.matches("^\\.mise\\.[^/]+\\.toml$".toRegex())) return true
+    return false
+}
+
 /**
  * Project-level service that manages the VFS listener for Mise TOML files.
  * This ensures that the listener is only registered once per project,
@@ -106,13 +116,7 @@ class MiseTomlFileListener(
             }
 
             private fun isLikelyMiseRelatedFile(file: VirtualFile): Boolean {
-                val name = file.name
-                if (name == "config.toml" || name == "mise.toml" || name == ".mise.toml") return true
-                if (name == "mise.local.toml" || name == ".mise.local.toml") return true
-                if (name.startsWith(".env")) return true
-                if (name.matches("^mise\\.[^/]+\\.toml$".toRegex())) return true
-                if (name.matches("^\\.mise\\.[^/]+\\.toml$".toRegex())) return true
-                return false
+                return isLikelyMiseRelatedFileName(file.name)
             }
         }
     }

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/setup/AbstractProjectSdkSetup.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/setup/AbstractProjectSdkSetup.kt
@@ -1,6 +1,11 @@
 package com.github.l34130.mise.core.setup
 
+import com.github.l34130.mise.core.MiseCoroutineService
 import com.github.l34130.mise.core.MiseConfigFileResolver
+import com.github.l34130.mise.core.MiseTomlFileListener
+import com.github.l34130.mise.core.cache.MiseCacheService
+import com.github.l34130.mise.core.cache.MiseProjectEvent
+import com.github.l34130.mise.core.cache.MiseProjectEventListener
 import com.github.l34130.mise.core.command.MiseCommandLineHelper
 import com.github.l34130.mise.core.command.MiseCommandLineNotFoundException
 import com.github.l34130.mise.core.command.MiseDevTool
@@ -20,10 +25,12 @@ import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.ProjectActivity
+import com.intellij.openapi.util.Key
 import com.intellij.openapi.vfs.LocalFileSystem
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.reflect.KClass
 
 abstract class AbstractProjectSdkSetup :
@@ -35,12 +42,13 @@ abstract class AbstractProjectSdkSetup :
         // Stable since 2025.2 https://github.com/JetBrains/intellij-community/commit/a498525e60e27a92d67c803569037e33cdfc2ce1
         @Suppress("UnstableApiUsage")
         currentThreadCoroutineScope().launch {
-            configureSdk(project, true)
+            runSdkConfigurationCheck(project, isUserInteraction = true, forceRefresh = false)
         }
     }
 
     override suspend fun execute(project: Project) {
-        configureSdk(project, false)
+        registerAutomaticRefresh(project)
+        runSdkConfigurationCheck(project, isUserInteraction = false, forceRefresh = false)
     }
 
     abstract fun getDevToolName(project: Project): MiseDevToolName
@@ -57,11 +65,40 @@ abstract class AbstractProjectSdkSetup :
 
     abstract fun <T : Configurable> getConfigurableClass(): KClass<out T>?
 
+    protected open suspend fun runSdkConfigurationCheck(
+        project: Project,
+        isUserInteraction: Boolean,
+        forceRefresh: Boolean,
+    ) {
+        configureSdk(project, isUserInteraction, forceRefresh)
+    }
+
+    private fun registerAutomaticRefresh(project: Project) {
+        project.service<MiseTomlFileListener>()
+
+        val registrationKey = refreshRegistrationKey()
+        if (project.getUserData(registrationKey) == true) return
+        project.putUserData(registrationKey, true)
+
+        MiseProjectEventListener.subscribe(project, project) { event ->
+            if (event.kind in AUTOMATIC_REFRESH_EVENTS) {
+                project.service<MiseCoroutineService>().scope.launch(Dispatchers.IO) {
+                    if (project.isDisposed) return@launch
+                    runSdkConfigurationCheck(project, isUserInteraction = false, forceRefresh = true)
+                }
+            }
+        }
+    }
+
     @Suppress("ktlint:max-line-length")
     private suspend fun configureSdk(
         project: Project,
         isUserInteraction: Boolean,
+        forceRefresh: Boolean,
     ) = withContext(Dispatchers.IO) {
+            if (forceRefresh) {
+                project.service<MiseCacheService>().invalidateAllCommands()
+            }
             val devToolName = getDevToolName(project)
             val miseNotificationService = project.service<MiseNotificationService>()
 
@@ -69,7 +106,7 @@ abstract class AbstractProjectSdkSetup :
 
             // Skip automatic SDK configuration if the project doesn't have mise config files
             // or if the specific tool is not configured in mise
-            if (!isUserInteraction && !hasToolConfigured(project, configEnvironment, devToolName)) {
+            if (!isUserInteraction && !hasToolConfigured(project, configEnvironment, devToolName, forceRefresh)) {
                 return@withContext
             }
             val toolsResult =
@@ -198,15 +235,16 @@ abstract class AbstractProjectSdkSetup :
         project: Project,
         configEnvironment: String?,
         devToolName: MiseDevToolName,
+        forceRefresh: Boolean,
     ): Boolean {
         val basePath = project.guessMiseProjectPath()
         val baseDir = LocalFileSystem.getInstance().findFileByPath(basePath)
             ?: return false
 
-        // First check if any mise config files exist
-        val configFiles = project.service<MiseConfigFileResolver>()
-            .resolveConfigFiles(baseDir, refresh = false, configEnvironment = configEnvironment)
-        if (configFiles.isEmpty()) return false
+        // First check if any mise-tracked config inputs exist
+        val trackedFiles = project.service<MiseConfigFileResolver>()
+            .resolveTrackedFiles(baseDir, refresh = forceRefresh, configEnvironment = configEnvironment)
+        if (trackedFiles.trackedInputs.isEmpty()) return false
 
         // Then check if the specific tool is configured in mise
         val toolsResult = MiseCommandLineHelper.getDevTools(
@@ -241,4 +279,19 @@ abstract class AbstractProjectSdkSetup :
         val sdkVersion: String,
         val sdkPath: String,
     )
+
+    private fun refreshRegistrationKey(): Key<Boolean> =
+        automaticRefreshRegistrationKeys.computeIfAbsent(javaClass.name) { className ->
+            Key.create("mise.sdk.setup.refresh.registered.$className")
+        }
+
+    private companion object {
+        val AUTOMATIC_REFRESH_EVENTS =
+            setOf(
+                MiseProjectEvent.Kind.TOML_CHANGED,
+                MiseProjectEvent.Kind.SETTINGS_CHANGED,
+                MiseProjectEvent.Kind.EXECUTABLE_CHANGED,
+            )
+        val automaticRefreshRegistrationKeys = ConcurrentHashMap<String, Key<Boolean>>()
+    }
 }

--- a/modules/core/src/test/kotlin/com/github/l34130/mise/core/MiseConfigFileResolverTest.kt
+++ b/modules/core/src/test/kotlin/com/github/l34130/mise/core/MiseConfigFileResolverTest.kt
@@ -155,6 +155,53 @@ class MiseConfigFileResolverTest : BasePlatformTestCase() {
         assertTrue(configPaths.contains(childToml.toString().replace('\\', '/')))
     }
 
+    fun `test resolveTrackedFiles indexes non toml tracked config inputs`() {
+        seedExecutableInfo()
+        val rootDir = Files.createTempDirectory("mise-non-toml-config-test")
+        val miseToml = rootDir.resolve("mise.toml").also { it.writeText("[tools]\ngo = '1.25'\n") }
+        val toolVersions = rootDir.resolve(".tool-versions").also { it.writeText("go 1.24\n") }
+
+        val baseDirVf =
+            LocalFileSystem.getInstance().refreshAndFindFileByPath(rootDir.toString().replace('\\', '/'))
+                ?: error("Failed to resolve project dir in VFS")
+        val resolver = project.service<MiseConfigFileResolver>()
+
+        val snapshot =
+            withCommandLineExecutor(
+                executor = { commandLine, _ ->
+                    val cmdStr = commandLine.commandLineString
+                    when {
+                        cmdStr.contains("config ls --json") -> {
+                            val json = """
+                                [
+                                  {"path": "${miseToml.toString().replace('\\', '/')}"}
+                                ]
+                            """.trimIndent()
+                            processOutput(stdout = json)
+                        }
+                        cmdStr.contains("config --tracked-configs") -> {
+                            processOutput(
+                                stdout =
+                                    listOf(miseToml, toolVersions)
+                                        .joinToString("\n") { it.toString().replace('\\', '/') } + "\n",
+                            )
+                        }
+                        else -> processOutput()
+                    }
+                },
+            ) {
+                runBlocking {
+                    resolver.resolveTrackedFiles(baseDirVf, refresh = true, configEnvironment = "test")
+                }
+            }
+
+        val toolVersionsPath = toolVersions.toString().replace('\\', '/')
+
+        assertEquals(listOf(miseToml.toString().replace('\\', '/')), snapshot.configTomlFiles.map { it.path })
+        assertTrue(snapshot.trackedInputs.map { it.path }.contains(toolVersionsPath))
+        assertTrue(snapshot.normalizedTrackedPaths.contains(toolVersionsPath))
+    }
+
     fun `test resolveConfigFiles ignores CLI configs in excluded folders`() {
         seedExecutableInfo()
         val rootDir = Files.createTempDirectory("mise-excluded-config-test")

--- a/modules/core/src/test/kotlin/com/github/l34130/mise/core/MiseTomlFileListenerTest.kt
+++ b/modules/core/src/test/kotlin/com/github/l34130/mise/core/MiseTomlFileListenerTest.kt
@@ -1,0 +1,11 @@
+package com.github.l34130.mise.core
+
+import junit.framework.TestCase
+
+class MiseTomlFileListenerTest : TestCase() {
+    fun `test likely mise related file names include tool versions files`() {
+        assertTrue(isLikelyMiseRelatedFileName(".tool-versions"))
+        assertTrue(isLikelyMiseRelatedFileName(".tool-versions.local"))
+        assertFalse(isLikelyMiseRelatedFileName(".tool-version"))
+    }
+}


### PR DESCRIPTION
## Summary
- Re-run automatic SDK checks when mise config, settings, or executable changes are detected
- Force-refresh mise command/config state before event-driven SDK checks so mismatch notifications see the new tool version
- Track non-TOML mise inputs such as .tool-versions and .tool-versions.local in the config watcher path

Closes #509

## Verification
- ./gradlew :mise-core:compileKotlin --no-parallel
- ./gradlew :mise-core:compileTestKotlin --no-parallel -Dkotlinx.coroutines.debug=off
- ./gradlew :mise-core:test --no-parallel --tests com.github.l34130.mise.core.MiseTomlFileListenerTest -Dkotlinx.coroutines.debug=off

## Notes
- Local run of ./gradlew :mise-core:test --no-parallel --tests com.github.l34130.mise.core.MiseConfigFileResolverTest -Dkotlinx.coroutines.debug=off did not finish in the local IntelliJ platform test runner and was interrupted.