### PR TITLE
Fix read action for project file index access

### DIFF
--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/MiseProjectFileIndex.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/MiseProjectFileIndex.kt
@@ -1,10 +1,17 @@
 package com.github.l34130.mise.core
 
+import com.intellij.openapi.application.runReadActionBlocking
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.openapi.vfs.VirtualFile
 
 internal fun Project.isExcludedFromMiseResolution(file: VirtualFile): Boolean {
     if (isDisposed || !file.isValid) return false
-    return ProjectFileIndex.getInstance(this).isExcluded(file)
+    return runReadActionBlocking {
+        if (isDisposed || !file.isValid) {
+            false
+        } else {
+            ProjectFileIndex.getInstance(this).isExcluded(file)
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Wrap mise ProjectFileIndex.isExcluded access in a read action
- Recheck project/file validity inside the read action before touching the file index

## Verification
- ./gradlew :mise-core:compileKotlin

Note: Full tests were not run because the test suite is currently known to be failing.