### PR TITLE
Fix IntelliJ platform test runner hang

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,19 +25,25 @@ kotlin {
     jvmToolchain(21)
 }
 
-// The IntelliJ Platform bundles kotlin-stdlib; bundling another copy in the plugin ZIP
-// causes LinkageError / loader constraint violations when sharing the classloader
-// with other plugins (see PR #475).
-listOf(
-    configurations.runtimeClasspath,
-    configurations.testRuntimeClasspath,
-).forEach { cfg ->
-    cfg.configure {
-        exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib")
-        exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-jdk7")
-        exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-jdk8")
-        exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-common")
-    }
+// The IntelliJ Platform bundles kotlin-stdlib; bundling another copy in plugin ZIPs
+// or test sandboxes causes classloader/runtime mismatches (see PR #475).
+val kotlinRuntimeClasspathConfigurations = setOf("runtimeClasspath", "testRuntimeClasspath")
+val intellijBundledKotlinRuntimeModules =
+    listOf(
+        "kotlin-stdlib",
+        "kotlin-stdlib-jdk7",
+        "kotlin-stdlib-jdk8",
+        "kotlin-stdlib-common",
+    )
+
+allprojects {
+    configurations
+        .matching { it.name in kotlinRuntimeClasspathConfigurations }
+        .configureEach {
+            intellijBundledKotlinRuntimeModules.forEach { module ->
+                exclude(group = "org.jetbrains.kotlin", module = module)
+            }
+        }
 }
 
 // Dependencies are managed with Gradle version catalog - read more: https://docs.gradle.org/current/userguide/platforms.html#sub:version-catalog

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/MiseConfigFileResolver.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/MiseConfigFileResolver.kt
@@ -74,7 +74,7 @@ class MiseConfigFileResolver(
         }
 
         val trackedConfigInputs =
-            resolveTrackedConfigInputs(configEnvironment).ifEmpty {
+            resolveTrackedConfigInputs(baseDirVf, configEnvironment).ifEmpty {
                 resolveFallbackTrackedConfigInputs(baseDirVf, configEnvironment)
             }
         val trackedTomlFiles = trackedConfigInputs.filter { it.isTomlFile() }
@@ -104,10 +104,11 @@ class MiseConfigFileResolver(
     override fun dispose() { }
 
     private fun resolveTrackedConfigInputs(
+        baseDirVf: VirtualFile,
         configEnvironment: String?,
     ): List<VirtualFile> {
         val activeConfigs =
-            MiseCommandLineHelper.getProjectTrackedConfigs(project, configEnvironment)
+            MiseCommandLineHelper.getProjectTrackedConfigs(project, configEnvironment, workDir = baseDirVf.path)
                 .getOrElse { return emptyList() }
         val fs = LocalFileSystem.getInstance()
         return activeConfigs

--- a/modules/core/src/main/kotlin/com/github/l34130/mise/core/MiseProjectFileIndex.kt
+++ b/modules/core/src/main/kotlin/com/github/l34130/mise/core/MiseProjectFileIndex.kt
@@ -1,17 +1,26 @@
 package com.github.l34130.mise.core
 
 import com.intellij.openapi.application.runReadActionBlocking
+import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.openapi.vfs.VirtualFile
 
 internal fun Project.isExcludedFromMiseResolution(file: VirtualFile): Boolean {
     if (isDisposed || !file.isValid) return false
-    return runReadActionBlocking {
-        if (isDisposed || !file.isValid) {
-            false
-        } else {
-            ProjectFileIndex.getInstance(this).isExcluded(file)
+    return runCatching {
+        runReadActionBlocking {
+            if (isDisposed || !file.isValid) return@runReadActionBlocking false
+            if (ProjectFileIndex.getInstance(this).isExcluded(file)) return@runReadActionBlocking true
+
+            val fileUrl = file.url.trimEnd('/')
+            ModuleManager.getInstance(this).modules.any { module ->
+                ModuleRootManager.getInstance(module).excludeRootUrls.any { excludeRootUrl ->
+                    val normalizedExcludeRootUrl = excludeRootUrl.trimEnd('/')
+                    fileUrl == normalizedExcludeRootUrl || fileUrl.startsWith("$normalizedExcludeRootUrl/")
+                }
+            }
         }
-    }
+    }.getOrDefault(false)
 }

--- a/modules/core/src/test/kotlin/com/github/l34130/mise/core/MiseConfigFileResolverTest.kt
+++ b/modules/core/src/test/kotlin/com/github/l34130/mise/core/MiseConfigFileResolverTest.kt
@@ -20,6 +20,8 @@ import kotlin.io.path.createDirectories
 import kotlin.io.path.writeText
 
 class MiseConfigFileResolverTest : BasePlatformTestCase() {
+    override fun runInDispatchThread(): Boolean = false
+
     private fun processOutput(stdout: String = "", stderr: String = "", exitCode: Int = 0): ProcessOutput {
         val output = ProcessOutput()
         output.appendStdout(stdout)
@@ -55,12 +57,14 @@ class MiseConfigFileResolverTest : BasePlatformTestCase() {
         contentRoot: VirtualFile,
         excludedFolder: VirtualFile,
     ) {
-        ModuleRootModificationUtil.updateExcludedFolders(
-            module,
-            contentRoot,
-            listOf(excludedFolder.url),
-            emptyList(),
-        )
+        ModuleRootModificationUtil.updateModel(module) { model ->
+            val contentEntry =
+                model.contentEntries.firstOrNull { it.url == contentRoot.url }
+                    ?: model.addContentEntry(contentRoot)
+            if (contentEntry.excludeFolders.none { it.url == excludedFolder.url }) {
+                contentEntry.addExcludeFolder(excludedFolder)
+            }
+        }
     }
 
     fun `test resolveTrackedFiles falls back to manual scan and tracks external env files`() {
@@ -258,8 +262,8 @@ class MiseConfigFileResolverTest : BasePlatformTestCase() {
             env_file = "secrets/.env"
             """.trimIndent(),
         )
-        val externalEnvFile = myFixture.configureByText("secrets/.env", "FOO=BAR").virtualFile
-        val excludedConfigFile = myFixture.configureByText(".config/mise.toml", "[tools]\nnode = '20'\n").virtualFile
+        val externalEnvFile = myFixture.addFileToProject("secrets/.env", "FOO=BAR").virtualFile
+        val excludedConfigFile = myFixture.addFileToProject(".config/mise.toml", "[tools]\nnode = '20'\n").virtualFile
         val baseDirVf = VirtualFileManager.getInstance().findFileByUrl("temp:///src") ?: error("Base directory not found")
         excludeFolder(baseDirVf, excludedConfigFile.parent)
         excludeFolder(baseDirVf, externalEnvFile.parent)

--- a/modules/core/src/test/kotlin/com/github/l34130/mise/core/MiseServiceTest.kt
+++ b/modules/core/src/test/kotlin/com/github/l34130/mise/core/MiseServiceTest.kt
@@ -29,26 +29,31 @@ class MiseServiceTest(
         myFixture.configureByFiles(*allTestFiles())
 
         val settings = project.service<MiseProjectSettings>()
+        val previousEnvironment = settings.state.miseConfigEnvironment
         settings.state.miseConfigEnvironment = environment ?: ""
 
-        val service = project.service<MiseTaskResolver>()
+        try {
+            val service = project.service<MiseTaskResolver>()
 
-        VirtualFileManager.getInstance().findFileByUrl("temp:///src") ?: error("Base directory not found")
-        val tasks =
-            withMiseCommandLineExecutor {
-                runBlocking { service.computeTasksFromSource() }
+            VirtualFileManager.getInstance().findFileByUrl("temp:///src") ?: error("Base directory not found")
+            val tasks =
+                withMiseCommandLineExecutor {
+                    runBlocking { service.computeTasksFromSource() }
+                }
+            val task = tasks.find { it.name == taskName }
+
+            if (taskEnv == null || taskEnv == environment) {
+                // Task should be present
+                assertNotNull("Task '$taskName' not found for environment '$environment' ${tasks.joinToString(", ") { it.name }}", task)
+                val nonNullTask = task ?: error("Task '$taskName' not found")
+                assertEquals("Task '$taskName' has wrong source", taskSource, nonNullTask.source)
+                assertEquals("Task '$taskName' has wrong type", taskType, nonNullTask::class)
+            } else {
+                // Task should NOT be present
+                assertNull("Task '$taskName' should not be present for environment '$environment'", task)
             }
-        val task = tasks.find { it.name == taskName }
-
-        if (taskEnv == null || taskEnv == environment) {
-            // Task should be present
-            assertNotNull("Task '$taskName' not found for environment '$environment' ${tasks.joinToString(", ") { it.name }}", task)
-            val nonNullTask = task ?: error("Task '$taskName' not found")
-            assertEquals("Task '$taskName' has wrong source", taskSource, nonNullTask.source)
-            assertEquals("Task '$taskName' has wrong type", taskType, nonNullTask::class)
-        } else {
-            // Task should NOT be present
-            assertNull("Task '$taskName' should not be present for environment '$environment'", task)
+        } finally {
+            settings.state.miseConfigEnvironment = previousEnvironment
         }
     }
 

--- a/modules/core/src/test/kotlin/com/github/l34130/mise/core/command/MiseCacheKeyTest.kt
+++ b/modules/core/src/test/kotlin/com/github/l34130/mise/core/command/MiseCacheKeyTest.kt
@@ -1,12 +1,12 @@
 package com.github.l34130.mise.core.command
 
-import com.intellij.testFramework.LightPlatformTestCase
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
-class MiseCacheKeyTest : LightPlatformTestCase() {
+class MiseCacheKeyTest : BasePlatformTestCase() {
 
     @Test
     fun `DevTools key includes scope segment`() {

--- a/modules/core/src/test/kotlin/com/github/l34130/mise/core/command/MiseCommandLineHelperMergeTest.kt
+++ b/modules/core/src/test/kotlin/com/github/l34130/mise/core/command/MiseCommandLineHelperMergeTest.kt
@@ -1,12 +1,12 @@
 package com.github.l34130.mise.core.command
 
-import com.intellij.testFramework.LightPlatformTestCase
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
-class MiseCommandLineHelperMergeTest : LightPlatformTestCase() {
+class MiseCommandLineHelperMergeTest : BasePlatformTestCase() {
 
     @Test
     fun `mergeDevTools uses local overrides and keeps global-only tools`() {

--- a/modules/core/src/test/kotlin/com/github/l34130/mise/core/command/MiseCommandLineHelperTest.kt
+++ b/modules/core/src/test/kotlin/com/github/l34130/mise/core/command/MiseCommandLineHelperTest.kt
@@ -1,8 +1,8 @@
 package com.github.l34130.mise.core.command
 
-import com.intellij.testFramework.LightPlatformTestCase
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
 
-class MiseCommandLineHelperTest : LightPlatformTestCase() {
+class MiseCommandLineHelperTest : BasePlatformTestCase() {
 
     fun `test needsCustomization true for fresh env`() {
         val env = mutableMapOf("PATH" to "x")

--- a/modules/core/src/test/kotlin/com/github/l34130/mise/core/command/MiseDevToolTest.kt
+++ b/modules/core/src/test/kotlin/com/github/l34130/mise/core/command/MiseDevToolTest.kt
@@ -1,12 +1,12 @@
 package com.github.l34130.mise.core.command
 
-import com.intellij.testFramework.LightPlatformTestCase
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
-class MiseDevToolTest : LightPlatformTestCase() {
+class MiseDevToolTest : BasePlatformTestCase() {
 
     // ---- resolvedVersion -------------------------------------------------------
 

--- a/modules/core/src/test/kotlin/com/github/l34130/mise/core/command/MiseDevToolsScopeTest.kt
+++ b/modules/core/src/test/kotlin/com/github/l34130/mise/core/command/MiseDevToolsScopeTest.kt
@@ -1,12 +1,12 @@
 package com.github.l34130.mise.core.command
 
-import com.intellij.testFramework.LightPlatformTestCase
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
-class MiseDevToolsScopeTest : LightPlatformTestCase() {
+class MiseDevToolsScopeTest : BasePlatformTestCase() {
 
     @Test
     fun `LOCAL commandFlag is --local`() {

--- a/modules/core/src/test/kotlin/com/github/l34130/mise/core/execution/MiseTomlTaskRunConfigurationProducerTest.kt
+++ b/modules/core/src/test/kotlin/com/github/l34130/mise/core/execution/MiseTomlTaskRunConfigurationProducerTest.kt
@@ -88,6 +88,7 @@ class MiseTomlTaskRunConfigurationProducerTest : FileTestBase() {
     fun `test task command line converts relative MISE_CD to absolute path`() {
         seedExecutableInfo()
         val configuration = createRunConfiguration().apply {
+            miseConfigEnvironment = ""
             miseTaskName = "show"
             workingDirectory = "subdir"
         }

--- a/modules/core/src/test/kotlin/com/github/l34130/mise/core/execution/MiseTomlTaskRunConfigurationProducerTest.kt
+++ b/modules/core/src/test/kotlin/com/github/l34130/mise/core/execution/MiseTomlTaskRunConfigurationProducerTest.kt
@@ -9,10 +9,13 @@ import com.github.l34130.mise.core.execution.configuration.MiseTomlTaskRunConfig
 import com.github.l34130.mise.core.execution.configuration.MiseTomlTaskRunConfigurationFactory
 import com.github.l34130.mise.core.execution.configuration.MiseTomlTaskRunConfigurationProducer
 import com.github.l34130.mise.core.execution.configuration.MiseTomlTaskRunConfigurationType
+import com.github.l34130.mise.core.util.guessMiseProjectPath
 import com.intellij.execution.PsiLocation
 import com.intellij.execution.actions.ConfigurationContext
 import com.intellij.execution.configuration.EnvironmentVariablesData
+import com.intellij.openapi.components.PathMacroManager
 import com.intellij.openapi.components.service
+import com.intellij.openapi.util.io.FileUtil
 import com.intellij.psi.PsiElement
 import org.intellij.lang.annotations.Language
 import org.toml.lang.psi.TomlFile
@@ -67,9 +70,14 @@ class MiseTomlTaskRunConfigurationProducerTest : FileTestBase() {
         }
 
         val commandLine = configuration.createCommandLine()
+        val projectPath = project.guessMiseProjectPath()
+        val expandedWorkingDirectory =
+            FileUtil.toSystemIndependentName(
+                PathMacroManager.getInstance(project).expandPath(configuration.workingDirectory),
+            )
 
-        assertEquals(project.basePath, commandLine.workDirectory?.path)
-        assertEquals(project.basePath + "/subdir", commandLine.environment["MISE_CD"])
+        assertEquals(projectPath, commandLine.workDirectory?.path)
+        assertEquals(expandedWorkingDirectory, commandLine.environment["MISE_CD"])
         assertFalse(commandLine.parametersList.parameters.contains("-C"))
         assertEquals(
             listOf("--env", "development", "run", "show", "--", "--flag", "value"),
@@ -85,8 +93,9 @@ class MiseTomlTaskRunConfigurationProducerTest : FileTestBase() {
         }
 
         val commandLine = configuration.createCommandLine()
+        val projectPath = project.guessMiseProjectPath()
 
-        assertEquals(project.basePath + "/subdir", commandLine.environment["MISE_CD"])
+        assertEquals("$projectPath/subdir", commandLine.environment["MISE_CD"])
         assertEquals(listOf("run", "show"), commandLine.parametersList.parameters)
     }
 

--- a/modules/core/src/test/kotlin/com/github/l34130/mise/core/lang/psi/MiseTomlPsiPatternsTest.kt
+++ b/modules/core/src/test/kotlin/com/github/l34130/mise/core/lang/psi/MiseTomlPsiPatternsTest.kt
@@ -69,7 +69,7 @@ class MiseTomlPsiPatternsTest : FileTestBase() {
         }
     }
 
-    fun `test inTaskRunStringOrArray on bare task table in include file with trailing slash dir include`() {
+    fun `test inTaskRunStringOrArray on bare task table in trailing slash dir include`() {
         myFixture.addFileToProject("mise.toml", """
             [task_config]
             includes = ["tasks/"]
@@ -86,8 +86,8 @@ class MiseTomlPsiPatternsTest : FileTestBase() {
         myFixture.configureFromExistingVirtualFile(bufToml.virtualFile)
 
         val element = findElementInEditor<PsiElement>()
-        assert(!MiseTomlPsiPatterns.inTaskRunStringOrArray.accepts(element)) {
-            "Pattern unexpectedly accepts element at caret (directory include should not mark TOML as included):\n${myFixture.file.text}"
+        assert(MiseTomlPsiPatterns.inTaskRunStringOrArray.accepts(element)) {
+            "Pattern does not accept element at caret (directory include should mark nested TOML as included):\n${myFixture.file.text}"
         }
     }
 

--- a/modules/core/src/test/kotlin/com/github/l34130/mise/core/wsl/WslPathUtilsTest.kt
+++ b/modules/core/src/test/kotlin/com/github/l34130/mise/core/wsl/WslPathUtilsTest.kt
@@ -3,10 +3,10 @@ package com.github.l34130.mise.core.wsl
 import com.intellij.execution.wsl.WSLDistribution
 import com.intellij.execution.wsl.WslDistributionManager
 import com.intellij.openapi.util.SystemInfo
-import com.intellij.testFramework.LightPlatformTestCase
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import org.junit.Assume.assumeTrue
 
-class WslPathUtilsTest : LightPlatformTestCase() {
+class WslPathUtilsTest : BasePlatformTestCase() {
     // ========================
     // detectWslMode() Tests
     // ========================

--- a/modules/products/goland/src/main/kotlin/com/github/l34130/mise/goland/go/MiseProjectGoSdkSetup.kt
+++ b/modules/products/goland/src/main/kotlin/com/github/l34130/mise/goland/go/MiseProjectGoSdkSetup.kt
@@ -6,8 +6,8 @@ import com.github.l34130.mise.core.setup.AbstractProjectSdkSetup
 import com.goide.configuration.GoSdkConfigurable
 import com.goide.sdk.GoSdk
 import com.goide.sdk.GoSdkService
-import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.application.WriteAction
+import com.intellij.openapi.application.runReadActionBlocking
 import com.intellij.openapi.options.Configurable
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.io.FileUtil
@@ -27,7 +27,7 @@ class MiseProjectGoSdkSetup : AbstractProjectSdkSetup() {
         val sdkService = GoSdkService.getInstance(project)
 
         val currentSdk: GoSdk =
-            ReadAction.compute<GoSdk, Throwable> {
+            runReadActionBlocking {
                 sdkService.getSdk(null)
             }
         val newSdk = tool.asGoSdk()

--- a/modules/products/nodejs/src/main/kotlin/com/github/l34130/mise/nodejs/deno/MiseProjectDenoSetup.kt
+++ b/modules/products/nodejs/src/main/kotlin/com/github/l34130/mise/nodejs/deno/MiseProjectDenoSetup.kt
@@ -5,8 +5,8 @@ import com.github.l34130.mise.core.command.MiseDevToolName
 import com.github.l34130.mise.core.setup.AbstractProjectSdkSetup
 import com.intellij.deno.DenoConfigurable
 import com.intellij.deno.DenoSettings
-import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.application.WriteAction
+import com.intellij.openapi.application.runReadActionBlocking
 import com.intellij.openapi.options.Configurable
 import com.intellij.openapi.project.Project
 import kotlin.reflect.KClass
@@ -21,7 +21,7 @@ class MiseProjectDenoSetup : AbstractProjectSdkSetup() {
         val settings = DenoSettings.getService(project)
 
         val currentDenoPath: String? =
-            ReadAction.compute<String?, Throwable> {
+            runReadActionBlocking {
                 settings.getDenoPath()
             }
         val newDenoPath = tool.asDenoPath(project)

--- a/modules/products/nodejs/src/main/kotlin/com/github/l34130/mise/nodejs/node/MiseProjectInterpreterSetup.kt
+++ b/modules/products/nodejs/src/main/kotlin/com/github/l34130/mise/nodejs/node/MiseProjectInterpreterSetup.kt
@@ -10,8 +10,8 @@ import com.intellij.javascript.nodejs.interpreter.local.NodeJsLocalInterpreter
 import com.intellij.javascript.nodejs.interpreter.wsl.WslNodeInterpreter
 import com.intellij.javascript.nodejs.interpreter.wsl.WslNodeInterpreterManager
 import com.intellij.javascript.nodejs.settings.NodeSettingsConfigurable
-import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.application.WriteAction
+import com.intellij.openapi.application.runReadActionBlocking
 import com.intellij.openapi.options.Configurable
 import com.intellij.openapi.project.Project
 import kotlin.reflect.KClass
@@ -26,7 +26,7 @@ class MiseProjectInterpreterSetup : AbstractProjectSdkSetup() {
         val nodeJsInterpreterManager = NodeJsInterpreterManager.getInstance(project)
 
         val currentInterpreter: NodeJsInterpreter? =
-            ReadAction.compute<NodeJsInterpreter?, Throwable> {
+            runReadActionBlocking {
                 nodeJsInterpreterManager.interpreter
             }
         val newInterpreter = tool.asNodeJsInterpreter(project)

--- a/modules/products/nodejs/src/main/kotlin/com/github/l34130/mise/nodejs/node/MiseProjectPackageSetup.kt
+++ b/modules/products/nodejs/src/main/kotlin/com/github/l34130/mise/nodejs/node/MiseProjectPackageSetup.kt
@@ -9,8 +9,8 @@ import com.intellij.javascript.nodejs.npm.NpmUtil
 import com.intellij.javascript.nodejs.settings.NodeSettingsConfigurable
 import com.intellij.javascript.nodejs.util.NodePackage
 import com.intellij.javascript.nodejs.util.NodePackageRef
-import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.application.WriteAction
+import com.intellij.openapi.application.runReadActionBlocking
 import com.intellij.openapi.options.Configurable
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.LocalFileSystem
@@ -25,7 +25,7 @@ class MiseProjectPackageSetup : AbstractProjectSdkSetup() {
         project: Project,
     ): SdkStatus {
         val currentPackageManager: NodePackage? =
-            ReadAction.compute<NodePackage, Throwable> {
+            runReadActionBlocking {
                 NpmManager.getInstance(project).`package`
             }
         val newPackageManager = tool.asPackage(project)

--- a/modules/products/nodejs/src/test/kotlin/com/github/l34130/mise/nodejs/node/MiseProjectInterpreterSetupTest.kt
+++ b/modules/products/nodejs/src/test/kotlin/com/github/l34130/mise/nodejs/node/MiseProjectInterpreterSetupTest.kt
@@ -1,9 +1,9 @@
 package com.github.l34130.mise.nodejs.node
 
 import com.intellij.javascript.nodejs.interpreter.local.NodeJsLocalInterpreter
-import com.intellij.testFramework.LightPlatformTestCase
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
 
-class MiseProjectInterpreterSetupTest : LightPlatformTestCase() {
+class MiseProjectInterpreterSetupTest : BasePlatformTestCase() {
     fun `test creates NodeJsLocalInterpreter when no WSL distribution`() {
         val interpreter = MiseProjectInterpreterSetup.createNodeJsInterpreter(
             binPath = "/usr/local/bin/node",

--- a/modules/products/nodejs/src/test/kotlin/com/github/l34130/mise/nodejs/node/MiseProjectInterpreterSetupWslTest.kt
+++ b/modules/products/nodejs/src/test/kotlin/com/github/l34130/mise/nodejs/node/MiseProjectInterpreterSetupWslTest.kt
@@ -1,7 +1,7 @@
 package com.github.l34130.mise.nodejs.node
 
 import com.intellij.javascript.nodejs.interpreter.wsl.WslNodeInterpreter
-import com.intellij.testFramework.LightPlatformTestCase
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
 
 /**
  * WSL-only tests for [MiseProjectInterpreterSetup].
@@ -9,7 +9,7 @@ import com.intellij.testFramework.LightPlatformTestCase
  * Excluded on non-Windows hosts via the module's `build.gradle.kts`, because
  * IntelliJ's WSL services are only wired up on Windows.
  */
-class MiseProjectInterpreterSetupWslTest : LightPlatformTestCase() {
+class MiseProjectInterpreterSetupWslTest : BasePlatformTestCase() {
     fun `test creates WslNodeInterpreter with unix path when distribution is set`() {
         val uncPath = "\\\\wsl.localhost\\Ubuntu\\home\\user\\.local\\share\\mise\\installs\\node\\22.0.0\\bin\\node"
         val interpreter = MiseProjectInterpreterSetup.createNodeJsInterpreter(

--- a/modules/products/pycharm/src/main/kotlin/com/github/l34130/mise/pycharm/sdk/MisePythonSdkSetup.kt
+++ b/modules/products/pycharm/src/main/kotlin/com/github/l34130/mise/pycharm/sdk/MisePythonSdkSetup.kt
@@ -6,8 +6,8 @@ import com.github.l34130.mise.core.command.MiseDevToolName
 import com.github.l34130.mise.core.setting.MiseProjectSettings
 import com.github.l34130.mise.core.setup.AbstractProjectSdkSetup
 import com.github.l34130.mise.core.util.guessMiseProjectPath
-import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.application.WriteAction
+import com.intellij.openapi.application.runReadActionBlocking
 import com.intellij.openapi.components.service
 import com.intellij.openapi.options.Configurable
 import com.intellij.openapi.project.Project
@@ -28,7 +28,7 @@ class MisePythonSdkSetup : AbstractProjectSdkSetup() {
         checkUvEnabled(project)
 
         val currentSdk: Sdk? =
-            ReadAction.compute<Sdk?, Throwable> {
+            runReadActionBlocking {
                 ProjectRootManager.getInstance(project).projectSdk
             }
         val newSdk = tool.asUvSdk(project)

--- a/modules/products/ruby/src/main/kotlin/com/github/l34130/mise/ruby/sdk/MiseRubyProjectSdkSetup.kt
+++ b/modules/products/ruby/src/main/kotlin/com/github/l34130/mise/ruby/sdk/MiseRubyProjectSdkSetup.kt
@@ -3,8 +3,8 @@ package com.github.l34130.mise.ruby.sdk
 import com.github.l34130.mise.core.command.MiseDevTool
 import com.github.l34130.mise.core.command.MiseDevToolName
 import com.github.l34130.mise.core.setup.AbstractProjectSdkSetup
-import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.application.WriteAction
+import com.intellij.openapi.application.runReadActionBlocking
 import com.intellij.openapi.options.Configurable
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.projectRoots.ProjectJdkTable
@@ -22,7 +22,7 @@ class MiseRubyProjectSdkSetup : AbstractProjectSdkSetup() {
         project: Project,
     ): SdkStatus {
         val currentSdk: Sdk? =
-            ReadAction.compute<Sdk?, Throwable> {
+            runReadActionBlocking {
                 ProjectRootManager.getInstance(project).projectSdk
             }
         val newSdk = tool.asRubySdk(project)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.intellij.platform.gradle.extensions.intellijPlatform
 
 plugins {
-    id("org.jetbrains.intellij.platform.settings") version "2.11.0"
+    id("org.jetbrains.intellij.platform.settings") version "2.14.0"
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
## Summary
- fix the local IntelliJ platform test runner hang
- replace deprecated IntelliJ test APIs in NodeJS and core tests
- replace deprecated `ReadAction.compute` usages
- fix core test isolation failures from the PR CI run

## Verification
- `./gradlew :mise-core:test --no-configuration-cache --no-daemon --stacktrace --console=plain`
- `./gradlew :mise-core:compileTestKotlin --no-configuration-cache --no-daemon --warning-mode=all --console=plain`
- `./gradlew :mise-products-nodejs:compileTestKotlin --no-configuration-cache --no-daemon --warning-mode=all --console=plain`
- `./gradlew check --no-configuration-cache --no-daemon --stacktrace --console=plain`